### PR TITLE
Update README with new size param

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Add it in you FlutterMap and configure it using `MarkerClusterGroupLayerOptions`
         ),
         MarkerClusterLayerOptions(
           maxClusterRadius: 120,
-          height: 40,
-          width: 40,
+          size: Size(40, 40),
           fitBoundsOptions: FitBoundsOptions(
             padding: EdgeInsets.all(50),
           ),


### PR DESCRIPTION
The example provided on README didn't match the one in the `/example` folder. Now it's good again!