### PR TITLE
Add optional onTap callback for Markers

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -597,6 +597,14 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           _centerMarkerController.isAnimating ||
           _fitBoundController.isAnimating) return null;
 
+      // This is handled as an optional callback rather than leaving the package
+      // user to wrap their Marker child Widget in a GestureDetector as only one
+      // GestureDetector gets triggered per gesture (usually the child one) and
+      // therefore this _onMarkerTap function never gets called.
+      if (widget.options.onMarkerTap != null) {
+        widget.options.onMarkerTap(marker.marker);
+      }
+
       if (!widget.options.centerMarkerOnClick) return null;
 
       final center = widget.map.center;

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -71,6 +71,9 @@ class MarkerClusterLayerOptions extends LayerOptions {
   /// Polygon's options that shown when tap cluster.
   final PolygonOptions polygonOptions;
 
+  /// Function to call when a Marker is tapped
+  final void Function(Marker) onMarkerTap;
+
   MarkerClusterLayerOptions({
     @required this.builder,
     this.markers = const [],
@@ -89,5 +92,6 @@ class MarkerClusterLayerOptions extends LayerOptions {
     this.spiderfyShapePositions,
     this.polygonOptions = const PolygonOptions(),
     this.showPolygon = true,
+    this.onMarkerTap,
   }) : assert(builder != null);
 }


### PR DESCRIPTION
This adds an optional onMarkerTap callback which gets triggered when
tapping a marker. My motivation is as follows:

I have an app which shows a popup when a marker is tapped. Originally I
implemented this by wrapping an Icon in a GestureBuilder in the Marker's
child Widget only to discover that only one GestureBuilder will get
triggered per gesture event (in this case tap). This meant that my
popups broke the centerMarkerOnClick functionality.