### PR TITLE
Support stream rebuilds

### DIFF
--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -111,5 +111,7 @@ class MarkerClusterLayerOptions extends LayerOptions {
     this.polygonOptions = const PolygonOptions(),
     this.showPolygon = true,
     this.onMarkerTap,
-  }) : assert(builder != null);
+    rebuild,
+  })  : assert(builder != null),
+        super(rebuild: rebuild);
 }


### PR DESCRIPTION
`flutter_map` LayerOptions are designed to support the use of a stream to trigger rebuilding of a specific layer. This change enables that for cluster layers.

I've tested rebuilding via the stream in my own application and it works well.