### PR TITLE
Add extras property override to markers to match flutter_map

### DIFF
--- a/lib/src/node/marker_node.dart
+++ b/lib/src/node/marker_node.dart
@@ -22,4 +22,7 @@ class MarkerNode implements Marker {
 
   @override
   double get width => marker.width;
+
+  @override
+  Map<String, dynamic> get extras => marker.extras;
 }


### PR DESCRIPTION
I opened a [PR](https://github.com/johnpryan/flutter_map/pull/553) on `flutter_map` repo introducing `Marker.extras` property. 

So we need this update here too as soon as the `flutter_map` package includes this update. 

For context: I needed to add extra properties to markers (so I can sum this props to show a total number on the cluster).

Please tell me if I need to change anything.

Thanks!