### PR TITLE
Add popups

### DIFF
--- a/example/.flutter-plugins-dependencies
+++ b/example/.flutter-plugins-dependencies
@@ -1,1 +1,0 @@
-{"_info":"// This is a generated file; do not edit or check into version control.","dependencyGraph":[{"name":"path_provider","dependencies":[]},{"name":"sqflite","dependencies":[]}]}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,6 +25,8 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  final PopupController _popupController = PopupController();
+
   List<Marker> markers;
   int pointIndex;
   List points = [
@@ -116,6 +118,8 @@ class _HomePageState extends State<HomePage> {
           plugins: [
             MarkerClusterPlugin(),
           ],
+          onTap: (_) => _popupController
+              .hidePopup(), // Hide popup when the map is tapped.
         ),
         layers: [
           TileLayerOptions(
@@ -134,6 +138,20 @@ class _HomePageState extends State<HomePage> {
                 borderColor: Colors.blueAccent,
                 color: Colors.black12,
                 borderStrokeWidth: 3),
+            popupOptions: PopupOptions(
+                popupSnap: PopupSnap.top,
+                popupController: _popupController,
+                popupBuilder: (_, marker) => Container(
+                      width: 200,
+                      height: 100,
+                      color: Colors.white,
+                      child: GestureDetector(
+                        onTap: () => debugPrint("Popup tap!"),
+                        child: Text(
+                          "Container popup for marker at ${marker.point}",
+                        ),
+                      ),
+                    )),
             builder: (context, markers) {
               return FloatingActionButton(
                 child: Text(markers.length.toString()),

--- a/lib/flutter_map_marker_cluster.dart
+++ b/lib/flutter_map_marker_cluster.dart
@@ -3,3 +3,5 @@ library flutter_map_marker_cluster;
 export 'src/marker_cluster_layer.dart';
 export 'src/marker_cluster_layer_options.dart';
 export 'src/marker_cluster_plugin.dart';
+
+export 'package:flutter_map_marker_popup/flutter_map_marker_popup.dart';

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -30,8 +30,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
   int _maxZoom;
   int _minZoom;
   int _currentZoom;
-  int _previusZoom;
-  double _previusZoomDouble;
+  int _previousZoom;
+  double _previousZoomDouble;
   AnimationController _zoomController;
   AnimationController _fitBoundController;
   AnimationController _centerMarkerController;
@@ -156,7 +156,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       _addLayer(MarkerNode(marker));
     }
 
-    _topClusterLevel.recalulateBounds();
+    _topClusterLevel.recalculateBounds();
   }
 
   _removeFromNewPosToMyPosGridUnclustered(MarkerNode marker, int zoom) {
@@ -420,11 +420,11 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         return List<Widget>();
       }
 
-      // fadein if
+      // fade in if
       // animating and
-      // zoomin and parent has the previus zoom
+      // zoom in and parent has the previous zoom
       if (_zoomController.isAnimating &&
-          (_currentZoom > _previusZoom && layer.parent.zoom == _previusZoom)) {
+          (_currentZoom > _previousZoom && layer.parent.zoom == _previousZoom)) {
         // marker
         layers.add(_buildMarker(
             layer,
@@ -443,11 +443,11 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         return List<Widget>();
       }
 
-      // fadein if
+      // fade in if
       // animating and
-      // zoomout and children is more than one or zoomin and father has same point
+      // zoom out and children is more than one or zoom in and father has same point
       if (_zoomController.isAnimating &&
-          (_currentZoom < _previusZoom && layer.children.length > 1)) {
+          (_currentZoom < _previousZoom && layer.children.length > 1)) {
         // cluster
         layers.add(_buildCluster(layer, FadeType.FadeIn));
         // children
@@ -475,7 +475,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           widget.options.onMarkersClustered(markersGettingClustered);
         }
       } else if (_zoomController.isAnimating &&
-          (_currentZoom > _previusZoom && layer.parent.point != layer.point)) {
+          (_currentZoom > _previousZoom && layer.parent.point != layer.point)) {
         // cluster
         layers.add(_buildCluster(
             layer,
@@ -497,8 +497,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
   }
 
   List<Widget> _buildLayers() {
-    if (widget.map.zoom != _previusZoomDouble) {
-      _previusZoomDouble = widget.map.zoom;
+    if (widget.map.zoom != _previousZoomDouble) {
+      _previousZoomDouble = widget.map.zoom;
 
       _unspiderfy();
     }
@@ -510,17 +510,17 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     if (_polygon != null) layers.add(_polygon);
 
     if (zoom < _currentZoom || zoom > _currentZoom) {
-      _previusZoom = _currentZoom;
+      _previousZoom = _currentZoom;
       _currentZoom = zoom;
 
       _zoomController
         ..reset()
         ..forward().then((_) => setState(() {
               _hidePolygon();
-            })); // for remove previus layer (animation)
+            })); // for remove previous layer (animation)
     }
 
-    _topClusterLevel.recurvisely(_currentZoom, (layer) {
+    _topClusterLevel.recursively(_currentZoom, (layer) {
       layers.addAll(_buildLayer(layer));
     });
 
@@ -540,7 +540,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         return null;
       }
 
-      // check if children can uncluster
+      // check if children can un-cluster
       final cannotDivide = cluster.markers.every((marker) =>
           marker.parent.zoom == _maxZoom &&
           marker.parent == cluster.markers[0].parent);
@@ -673,7 +673,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
 
   @override
   void initState() {
-    _currentZoom = _previusZoom = widget.map.zoom.ceil();
+    _currentZoom = _previousZoom = widget.map.zoom.ceil();
     _minZoom = widget.map.options.minZoom?.ceil() ?? 1;
     _maxZoom = widget.map.options.maxZoom?.floor() ?? 20;
 

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -354,16 +354,32 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
   _unspiderfy() {
     switch (_spiderfyController.status) {
       case AnimationStatus.completed:
+        List<Marker> markersGettingClustered = _spiderfyCluster.markers
+            .map((markerNode) => markerNode.marker)
+            .toList();
+
         _spiderfyController.reverse().then((_) => setState(() {
               _spiderfyCluster = null;
             }));
+
+        if (widget.options.onMarkersClustered != null) {
+          widget.options.onMarkersClustered(markersGettingClustered);
+        }
         break;
       case AnimationStatus.forward:
+        List<Marker> markersGettingClustered = _spiderfyCluster.markers
+            .map((markerNode) => markerNode.marker)
+            .toList();
+
         _spiderfyController
           ..stop()
           ..reverse().then((_) => setState(() {
                 _spiderfyCluster = null;
               }));
+
+        if (widget.options.onMarkersClustered != null) {
+          widget.options.onMarkersClustered(markersGettingClustered);
+        }
         break;
       default:
         break;
@@ -435,8 +451,11 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         // cluster
         layers.add(_buildCluster(layer, FadeType.FadeIn));
         // children
+        List<Marker> markersGettingClustered = List<Marker>();
         layer.children.forEach((child) {
           if (child is MarkerNode) {
+            markersGettingClustered.add(child.marker);
+
             layers.add(_buildMarker(
                 child,
                 _zoomController,
@@ -451,6 +470,10 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
                 _getPixelFromCluster(child, layer.point)));
           }
         });
+
+        if (widget.options.onMarkersClustered != null) {
+          widget.options.onMarkersClustered(markersGettingClustered);
+        }
       } else if (_zoomController.isAnimating &&
           (_currentZoom > _previusZoom && layer.parent.point != layer.point)) {
         // cluster

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map_marker_popup/extension_api.dart';
 import 'package:flutter_map_marker_cluster/src/anim_type.dart';
 import 'package:flutter_map_marker_cluster/src/core/distance_grid.dart';
 import 'package:flutter_map_marker_cluster/src/core/quick_hull.dart';
@@ -362,6 +363,9 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
               _spiderfyCluster = null;
             }));
 
+        if (widget.options.popupOptions != null) {
+          widget.options.popupOptions.popupController.hidePopupIfShowingFor(markersGettingClustered);
+        }
         if (widget.options.onMarkersClustered != null) {
           widget.options.onMarkersClustered(markersGettingClustered);
         }
@@ -377,6 +381,9 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
                 _spiderfyCluster = null;
               }));
 
+        if (widget.options.popupOptions != null) {
+          widget.options.popupOptions.popupController.hidePopupIfShowingFor(markersGettingClustered);
+        }
         if (widget.options.onMarkersClustered != null) {
           widget.options.onMarkersClustered(markersGettingClustered);
         }
@@ -471,6 +478,9 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           }
         });
 
+        if (widget.options.popupOptions != null) {
+          widget.options.popupOptions.popupController.hidePopupIfShowingFor(markersGettingClustered);
+        }
         if (widget.options.onMarkersClustered != null) {
           widget.options.onMarkersClustered(markersGettingClustered);
         }
@@ -523,6 +533,18 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     _topClusterLevel.recursively(_currentZoom, (layer) {
       layers.addAll(_buildLayer(layer));
     });
+
+    final PopupOptions popupOptions = widget.options.popupOptions;
+    if (popupOptions != null) {
+      layers.add(
+        MarkerPopup(
+          mapState: widget.map,
+          popupController: popupOptions.popupController,
+          snap: popupOptions.popupSnap,
+          popupBuilder: popupOptions.popupBuilder,
+        ),
+      );
+    }
 
     return layers;
   }
@@ -620,6 +642,10 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       if (_zoomController.isAnimating ||
           _centerMarkerController.isAnimating ||
           _fitBoundController.isAnimating) return null;
+
+      if (widget.options.popupOptions != null) {
+        widget.options.popupOptions.popupController.togglePopup(marker.marker);
+      }
 
       // This is handled as an optional callback rather than leaving the package
       // user to wrap their Marker child Widget in a GestureDetector as only one

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -92,6 +92,9 @@ class MarkerClusterLayerOptions extends LayerOptions {
   /// Function to call when a Marker is tapped
   final void Function(Marker) onMarkerTap;
 
+  /// Function to call when markers are clustered
+  final void Function(List<Marker>) onMarkersClustered;
+
   MarkerClusterLayerOptions({
     @required this.builder,
     this.markers = const [],
@@ -111,5 +114,6 @@ class MarkerClusterLayerOptions extends LayerOptions {
     this.polygonOptions = const PolygonOptions(),
     this.showPolygon = true,
     this.onMarkerTap,
+    this.onMarkersClustered,
   }) : assert(builder != null);
 }

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map_marker_popup/extension_api.dart';
 
 class PolygonOptions {
   final Color color;
@@ -33,6 +34,18 @@ class AnimationsOptions {
     this.spiderfy = const Duration(milliseconds: 500),
     this.fitBoundCurves = Curves.fastOutSlowIn,
     this.centerMarkerCurves = Curves.fastOutSlowIn,
+  });
+}
+
+class PopupOptions {
+  final PopupBuilder popupBuilder;
+  final PopupController popupController;
+  final PopupSnap popupSnap;
+
+  const PopupOptions({
+    this.popupBuilder,
+    this.popupSnap = PopupSnap.top,
+    this.popupController,
   });
 }
 
@@ -95,6 +108,9 @@ class MarkerClusterLayerOptions extends LayerOptions {
   /// Function to call when markers are clustered
   final void Function(List<Marker>) onMarkersClustered;
 
+  /// Popup's options that show when tapping markers or via the PopupController.
+  final PopupOptions popupOptions;
+
   MarkerClusterLayerOptions({
     @required this.builder,
     this.markers = const [],
@@ -115,5 +131,6 @@ class MarkerClusterLayerOptions extends LayerOptions {
     this.showPolygon = true,
     this.onMarkerTap,
     this.onMarkersClustered,
+    this.popupOptions,
   }) : assert(builder != null);
 }

--- a/lib/src/node/marker_cluster_node.dart
+++ b/lib/src/node/marker_cluster_node.dart
@@ -48,10 +48,10 @@ class MarkerClusterNode {
 
   removeChild(dynamic child) {
     children.remove(child);
-    recalulateBounds();
+    recalculateBounds();
   }
 
-  recalulateBounds() {
+  recalculateBounds() {
     bounds = LatLngBounds();
 
     markers.forEach((marker) {
@@ -60,12 +60,12 @@ class MarkerClusterNode {
 
     children.forEach((child) {
       if (child is MarkerClusterNode) {
-        child.recalulateBounds();
+        child.recalculateBounds();
       }
     });
   }
 
-  recurvisely(int zoomLevel, Function(dynamic) fn) {
+  recursively(int zoomLevel, Function(dynamic) fn) {
     if (zoom == zoomLevel) {
       fn(this);
       return;
@@ -76,7 +76,7 @@ class MarkerClusterNode {
         fn(child);
       }
       if (child is MarkerClusterNode) {
-        child.recurvisely(zoomLevel, fn);
+        child.recursively(zoomLevel, fn);
       }
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 
   flutter_map: ^0.8.2
   latlong: ^0.6.1
+  flutter_map_marker_popup: ^0.1.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Adds the ability to show a customisable popup Widget for a marker. This
is shown when tapping a marker and it can also be controlled using the
PopupController (see the example).

Popups are hidden when the popup is clustered or 'unspiderfyed'.

**Note:**

There is a commit containing spelling fixes, if you don't want to include that let me know and I'll remove it: https://github.com/lpongetti/flutter_map_marker_cluster/commit/6d3486067e27cf3feb26163a424df75be272ae8d

There is also a commit from an older PR that didn't get merged (#37) which I left in because it added some code that this popup needs. If you don't want to merge the onMarkersClustered change I can also remove that.

If you want to see an example of a more 'fancy' popup have a look at the example in: https://github.com/rorystephenson/flutter_map_marker_popup . I left the example popup basic for this package so the example doesn't get too messy.