### PR TITLE
implemented displayInVisibleArea

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -536,9 +536,15 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
             })); // for remove previous layer (animation)
     }
 
-    _topClusterLevel.recursively(
-        _currentZoom, widget.options.disableClusteringAtZoom, (layer) {
-      layers.addAll(_buildLayer(layer));
+    LatLngBounds bounds;
+    bounds = widget.map.getBounds();
+
+    _topClusterLevel.recursively( _currentZoom, widget.options.disableClusteringAtZoom, (layer) {
+      if (widget.options.displayInVisibleArea && bounds.contains(layer.point)) {
+        layers.addAll(_buildLayer(layer));
+      } else {
+        layers.addAll(_buildLayer(layer));
+      }
     });
 
     final PopupOptions popupOptions = widget.options.popupOptions;

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -90,6 +90,9 @@ class MarkerClusterLayerOptions extends LayerOptions {
   /// If set, at this zoom level and below, markers will not be clustered. This defaults to 20 (max zoom)
   final int disableClusteringAtZoom;
 
+  /// Display markers only in the visible area. Default to true.
+  final bool displayInVisibleArea;
+
   /// Increase to increase the distance away that spiral spiderfied markers appear from the center
   final int spiderfySpiralDistanceMultiplier;
 
@@ -126,6 +129,7 @@ class MarkerClusterLayerOptions extends LayerOptions {
     this.anchor,
     this.maxClusterRadius = 80,
     this.disableClusteringAtZoom = 20,
+    this.displayInVisibleArea = true,
     this.animationsOptions = const AnimationsOptions(),
     this.fitBoundsOptions =
         const FitBoundsOptions(padding: EdgeInsets.all(12.0)),


### PR DESCRIPTION
Added `displayInVisibleArea` option to reduce the number of rendered markers.
Only those markers that are in the visible area are displayed/rendered.