### PR TITLE
Enable cluster recalculation on markers update

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -536,9 +536,15 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
             })); // for remove previous layer (animation)
     }
 
-    _topClusterLevel.recursively(
-        _currentZoom, widget.options.disableClusteringAtZoom, (layer) {
-      layers.addAll(_buildLayer(layer));
+    LatLngBounds bounds;
+    bounds = widget.map.getBounds();
+
+    _topClusterLevel.recursively( _currentZoom, widget.options.disableClusteringAtZoom, (layer) {
+      if (widget.options.displayInVisibleArea && bounds.contains(layer.point)) {
+        layers.addAll(_buildLayer(layer));
+      } else {
+        layers.addAll(_buildLayer(layer));
+      }
     });
 
     final PopupOptions popupOptions = widget.options.popupOptions;

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -90,6 +90,9 @@ class MarkerClusterLayerOptions extends LayerOptions {
   /// If set, at this zoom level and below, markers will not be clustered. This defaults to 20 (max zoom)
   final int disableClusteringAtZoom;
 
+  /// Display markers only in the visible area. Default to true.
+  final bool displayInVisibleArea;
+
   /// Increase to increase the distance away that spiral spiderfied markers appear from the center
   final int spiderfySpiralDistanceMultiplier;
 
@@ -126,6 +129,7 @@ class MarkerClusterLayerOptions extends LayerOptions {
     this.anchor,
     this.maxClusterRadius = 80,
     this.disableClusteringAtZoom = 20,
+    this.displayInVisibleArea = true,
     this.animationsOptions = const AnimationsOptions(),
     this.fitBoundsOptions =
         const FitBoundsOptions(padding: EdgeInsets.all(12.0)),

--- a/lib/src/marker_cluster_plugin.dart
+++ b/lib/src/marker_cluster_plugin.dart
@@ -4,10 +4,39 @@ import 'package:flutter_map_marker_cluster/src/marker_cluster_layer.dart';
 import 'package:flutter_map_marker_cluster/src/marker_cluster_layer_options.dart';
 
 class MarkerClusterPlugin extends MapPlugin {
+  MarkerClusterLayer _oldLayer;
+  int _markersHashCode;
+
+  /// Enable cluster recalculation on markers update. Default to false.
+  final bool enableClusterRecalculationOnMarkersUpdate;
+
+  MarkerClusterPlugin({
+    this.enableClusterRecalculationOnMarkersUpdate = false,
+  });
+
   @override
   Widget createLayer(
       LayerOptions options, MapState mapState, Stream<void> stream) {
-    return MarkerClusterLayer(options, mapState, stream);
+    if (!enableClusterRecalculationOnMarkersUpdate) {
+      return MarkerClusterLayer(options, mapState, stream);
+    }
+
+    MarkerClusterLayerOptions layerOptions = options;
+    int hashCode;
+    hashCode = layerOptions.markers.hashCode;
+
+    if (hashCode == _markersHashCode) {
+      if (_oldLayer != null) {
+        return _oldLayer;
+      } else {
+        _oldLayer = MarkerClusterLayer(options, mapState, stream);
+        return _oldLayer;
+      }
+    } else {
+      _markersHashCode = hashCode;
+      _oldLayer = MarkerClusterLayer(options, mapState, stream);
+      return _oldLayer;
+    }
   }
 
   @override


### PR DESCRIPTION
@lpongetti The ability to recreate `MarkerClusterLayer` only when updating the list of markers has been implemented.

Added `enableClusterRecalculationOnMarkersUpdate` to the `MarkerClusterPlugin`.

```
return FlutterMap(
      mapController: mapController,
      options: MapOptions(
        ...
        plugins: [
          MarkerClusterPlugin(enableClusterRecalculationOnMarkersUpdate: true),    <-------------------------- update
        ],
      ),
      layers: [
        TileLayerOptions( ... ),
        MarkerClusterLayerOptions(
          maxClusterRadius: 120,
          size: Size(40, 40),
          fitBoundsOptions: FitBoundsOptions(
            padding: EdgeInsets.all(50),
          ),
          showPolygon: false,
          disableClusteringAtZoom: 12,
          markers: statefulMapController.markers,
          builder: (context, markers) {
            return FloatingActionButton(
              child: Text(markers.length.toString()),
              onPressed: null,
            );
          },
        ),
      ],
    );
```