### PR TITLE
add key so that states are preserved when map moves

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -211,6 +211,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         _translateAnimation(controller, translate, pos, newPos);
 
     return AnimatedBuilder(
+      key: Key('marker-${marker.hashCode}'),
       animation: controller,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,


### PR DESCRIPTION

When you zoom or pan the map, the order and number of markers might change from one build to the next. As a result the matching of widget tree and element tree is not optimal. When using stateful widgets as markers, the widget-state connection is updated often resulting in unnecessary builds.

Simply adding a key solves this issue.


