### PR TITLE
Add support for newest version of flutter_map dep

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_map: ^0.10.1+1
+  flutter_map: ">=0.10.1+1 <1.0.0"
   latlong: ^0.6.1
   flutter_map_marker_popup: ^0.1.4
 


### PR DESCRIPTION
There is a new version `^0.11.0` which has vast improvements. My suggestion is to support up to major change if there are no contraindications I'm not aware of.