### PR TITLE
Ensure cluster is split when tapping it

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -1,8 +1,8 @@
 import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/plugin_api.dart';
-import 'package:flutter_map_marker_popup/extension_api.dart';
 import 'package:flutter_map_marker_cluster/src/anim_type.dart';
 import 'package:flutter_map_marker_cluster/src/core/distance_grid.dart';
 import 'package:flutter_map_marker_cluster/src/core/quick_hull.dart';
@@ -10,6 +10,7 @@ import 'package:flutter_map_marker_cluster/src/core/spiderfy.dart';
 import 'package:flutter_map_marker_cluster/src/marker_cluster_layer_options.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_cluster_node.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_node.dart';
+import 'package:flutter_map_marker_popup/extension_api.dart';
 import 'package:latlong/latlong.dart';
 
 class MarkerClusterLayer extends StatefulWidget {
@@ -593,9 +594,16 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           [], (result, marker) => result..add(marker.point)));
 
       final center = widget.map.center;
-      final dest = widget.map
+      var dest = widget.map
           .getBoundsCenterZoom(cluster.bounds, widget.options.fitBoundsOptions);
 
+      // Force a jump to the next zoom level if that wouldn't otherwise occur.
+      if (dest.zoom < cluster.zoom) {
+        dest = CenterZoom(
+          center: dest.center,
+          zoom: cluster.zoom.toDouble() + 0.0000000001,
+        );
+      }
       final _latTween =
           Tween<double>(begin: center.latitude, end: dest.center.latitude);
       final _lngTween =


### PR DESCRIPTION
I noticed that sometimes when tapping a cluster it would not uncluster.

I wrote this fix a while ago but it felt a bit hacky so I didn't open a pull-request however I thought I should at least share it with you so that you/others are aware.

---

From memory the issue is that it's possible that the new calculated zoom level is slightly less than the cluster's zoom level so the zoom/uncluster animation would start but then it would zoom back out and the uncluster would not happen.

I have an app with ~1300 markers and I came upon this issue randomly, unfortunately I didn't capture it in a reproducible way so it's not very easy to test. However since adding this fix I haven't run in to the issue again.

Adding 0.0000001 was necessary as sometimes the new zoom would exactly equal the cluster zoom so it wouldn't uncluster.

Let me know if you want any more info about the settings I use for this plugin.

---

Uso questo plugin da un anno e funziona benissimo, grazie mille.