### PR TITLE
MarkerClusterLayerWidget added to support the new way to create layers for the flutter map (with widgets)

### DIFF
--- a/lib/flutter_map_marker_cluster.dart
+++ b/lib/flutter_map_marker_cluster.dart
@@ -1,6 +1,7 @@
 library flutter_map_marker_cluster;
 
 export 'src/marker_cluster_layer.dart';
+export 'src/marker_cluster_layer_widget.dart';
 export 'src/marker_cluster_layer_options.dart';
 export 'src/marker_cluster_plugin.dart';
 

--- a/lib/src/marker_cluster_layer_widget.dart
+++ b/lib/src/marker_cluster_layer_widget.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/plugin_api.dart';
+
+import '../flutter_map_marker_cluster.dart';
+
+class MarkerClusterLayerWidget extends StatelessWidget {
+  final MarkerClusterLayerOptions options;
+
+  MarkerClusterLayerWidget({Key key, @required this.options}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final mapState = MapState.of(context);
+    return MarkerClusterLayer(options, mapState, mapState.onMoved);
+  }
+}


### PR DESCRIPTION
[flutter_map](https://pub.dev/packages/flutter_map) changed the way of adding layers to the map. Previously, `layers` were added via the `layer` property, now there is a `children` property. For this `children` property we need specific widgets, like the `MarkerLayerWidget` provided by the [flutter_map](https://pub.dev/packages/flutter_map). With the created `MarkerClusterLayerWidget` we can now use the new way and provide a specific widget to the `children` property.

```
########## old way:

FlutterMap(
  plugins: [
    MarkerClusterPlugin(),
  ],
  layers: [
    TileLayerOptions(),
    MarkerClusterLayerOptions(),
  ],
);

########## new way:

FlutterMap(
  plugins: [
    MarkerClusterPlugin(),
  ],
  children: [
    TileLayerWidget(
      options: TileLayerOptions(),
    ),
    MarkerClusterLayerWidget(
      options: MarkerClusterLayerOptions(),
    ),
  ],
);
```
