### PR TITLE
Upgrade to flutter_map_marker_popup v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.x.y] - 23/09/2021
+
+- Upgrade to flutter_map_marker_popup v2.0.0 which now supports showing multiple
+  popups at once. The default behaviour when using popups remains single-popup
+  but some breaking changes in PopupController were required:
+
+  - hidePopups -> hideAllPopups
+  - hidePopupIfShowingFor -> hidePopupsOnlyFor
+  - showPopup -> showPopupsOnlyFor
+
+  If you wish to show multiple popups at once you will want to change the 
+  default MarkerTapBehavior, see the documentation in PopupMarkerLayerOptions.
+
 ## [0.4.0] - 21/06/2021
 
 - Null safety update

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -116,8 +116,8 @@ class _HomePageState extends State<HomePage> {
           plugins: [
             MarkerClusterPlugin(),
           ],
-          onTap: (_) => _popupController
-              .hidePopup(), // Hide popup when the map is tapped.
+          onTap: (_, __) => _popupController
+              .hideAllPopups(), // Hide popup when the map is tapped.
         ),
         layers: [
           TileLayerOptions(

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -369,7 +369,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
 
         if (widget.options.popupOptions != null) {
           widget.options.popupOptions!.popupController
-              .hidePopupIfShowingFor(markersGettingClustered);
+              .hidePopupsOnlyFor(markersGettingClustered);
         }
         if (widget.options.onMarkersClustered != null) {
           widget.options.onMarkersClustered!(markersGettingClustered);
@@ -388,7 +388,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
 
         if (widget.options.popupOptions != null) {
           widget.options.popupOptions!.popupController
-              .hidePopupIfShowingFor(markersGettingClustered);
+              .hidePopupsOnlyFor(markersGettingClustered);
         }
         if (widget.options.onMarkersClustered != null) {
           widget.options.onMarkersClustered!(markersGettingClustered);
@@ -486,7 +486,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
 
         if (widget.options.popupOptions != null) {
           widget.options.popupOptions!.popupController
-              .hidePopupIfShowingFor(markersGettingClustered);
+              .hidePopupsOnlyFor(markersGettingClustered);
         }
         if (widget.options.onMarkersClustered != null) {
           widget.options.onMarkersClustered!(markersGettingClustered);
@@ -669,7 +669,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           _fitBoundController.isAnimating) return null;
 
       if (widget.options.popupOptions != null) {
-        widget.options.popupOptions!.popupController.togglePopup(marker.marker);
+        final popupOptions = widget.options.popupOptions!;
+        popupOptions.markerTapBehavior.apply(marker.marker, popupOptions.popupController);
       }
 
       // This is handled as an optional callback rather than leaving the package

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_cluster_node.dart';
 import 'package:flutter_map_marker_popup/extension_api.dart';
 
@@ -53,7 +54,18 @@ class PopupOptions {
   /// animation.
   final PopupAnimation? popupAnimation;
 
+  /// Whether or not the markers rotate counter clockwise to the map rotation,
+  /// defaults to false.
   final bool markerRotate;
+
+  /// The default MarkerTapBehavior is
+  /// [MarkerTapBehavior.togglePopupAndHideRest] which will toggle the popup of
+  /// the tapped marker and hide all other popups. This is a sensible default
+  /// when you only want to show a single popup at a time but if you show
+  /// multiple popups you probably want to use [MarkerTapBehavior.togglePopup].
+  ///
+  /// For more information and other options see [MarkerTapBehavior].
+  final MarkerTapBehavior markerTapBehavior;
 
   PopupOptions({
     required this.popupBuilder,
@@ -61,7 +73,9 @@ class PopupOptions {
     PopupController? popupController,
     this.popupAnimation,
     this.markerRotate = false,
-  }) : popupController = popupController ?? PopupController();
+    MarkerTapBehavior? markerTapBehavior,
+  }) : markerTapBehavior = markerTapBehavior ?? MarkerTapBehavior.togglePopupAndHideRest(),
+        popupController = popupController ?? PopupController();
 }
 
 typedef ClusterWidgetBuilder = Widget Function(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_map: ">=0.13.1 <1.0.0"
   latlong2: ^0.8.0
-  flutter_map_marker_popup: ^1.0.0
+  flutter_map_marker_popup: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Support multiple visible popups at once. The default behaviour remains
single-popup but some breaking changes in PopupController were required:

  - hidePopups -> hideAllPopups
  - hidePopupIfShowingFor -> hidePopupsOnlyFor
  - showPopup -> showPopupsOnlyFor

  If you wish to show multiple popups at once you will want to change the
  default MarkerTapBehavior, see the documentation in PopupMarkerLayerOptions.

@lpongetti Note I haven't changed the version number in CHANGELOG.md or pubspec,yaml as I'm not sure if you will want to bump the minor or major version number. I bumped the major version (to v2) in `flutter_map_marker_popup` since there were breaking changes involved and it was a big change conceptually to allow multiple popups to be visible however since popups is just a little part of this plugin maybe you only want to bump the minor version.