### PR TITLE
Support Marker rotate, rotateOrigin and rotateAlignment options

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -23,7 +23,8 @@ class MarkerClusterLayer extends StatefulWidget {
   _MarkerClusterLayerState createState() => _MarkerClusterLayerState();
 }
 
-class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProviderStateMixin {
+class _MarkerClusterLayerState extends State<MarkerClusterLayer>
+    with TickerProviderStateMixin {
   final Map<int, DistanceGrid<MarkerClusterNode>> _gridClusters = {};
   final Map<int, DistanceGrid<MarkerNode>> _gridUnclustered = {};
   late MarkerClusterNode _topClusterLevel;
@@ -43,7 +44,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
 
   CustomPoint<num> _getPixelFromPoint(LatLng point) {
     var pos = widget.map.project(point);
-    return pos.multiplyBy(widget.map.getZoomScale(widget.map.zoom, widget.map.zoom)) -
+    return pos.multiplyBy(
+            widget.map.getZoomScale(widget.map.zoom, widget.map.zoom)) -
         widget.map.getPixelOrigin();
   }
 
@@ -122,8 +124,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
             ..addChild(closest)
             ..addChild(marker);
 
-          _gridClusters[zoom]!
-              .addObject(newCluster, widget.map.project(newCluster.point, zoom.toDouble()));
+          _gridClusters[zoom]!.addObject(newCluster,
+              widget.map.project(newCluster.point, zoom.toDouble()));
 
           //First create any new intermediate parent clusters that don't exist
           var lastParent = newCluster;
@@ -134,8 +136,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
             );
             newParent.addChild(lastParent);
             lastParent = newParent;
-            _gridClusters[z]!
-                .addObject(lastParent, widget.map.project(closest.point, z.toDouble()));
+            _gridClusters[z]!.addObject(
+                lastParent, widget.map.project(closest.point, z.toDouble()));
           }
           parent.addChild(lastParent);
 
@@ -167,15 +169,18 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
     }
   }
 
-  Animation<double>? _fadeAnimation(AnimationController? controller, FadeType fade) {
-    if (fade == FadeType.FadeIn) return Tween<double>(begin: 0.0, end: 1.0).animate(controller!);
-    if (fade == FadeType.FadeOut) return Tween<double>(begin: 1.0, end: 0.0).animate(controller!);
+  Animation<double>? _fadeAnimation(
+      AnimationController? controller, FadeType fade) {
+    if (fade == FadeType.FadeIn)
+      return Tween<double>(begin: 0.0, end: 1.0).animate(controller!);
+    if (fade == FadeType.FadeOut)
+      return Tween<double>(begin: 1.0, end: 0.0).animate(controller!);
 
     return null;
   }
 
-  Animation<Point>? _translateAnimation(
-      AnimationController? controller, TranslateType translate, Point pos, Point? newPos) {
+  Animation<Point>? _translateAnimation(AnimationController? controller,
+      TranslateType translate, Point pos, Point? newPos) {
     if (translate == TranslateType.FromNewPosToMyPos)
       return Tween<Point>(
         begin: Point(newPos!.x, newPos.y),
@@ -201,7 +206,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
     final pos = myPos ?? _getPixelFromMarker(marker);
 
     var fadeAnimation = _fadeAnimation(controller, fade);
-    var translateAnimation = _translateAnimation(controller, translate, pos, newPos);
+    var translateAnimation =
+        _translateAnimation(controller, translate, pos, newPos);
 
     return AnimatedBuilder(
       key: Key('marker-${(marker.key ?? marker).hashCode}'),
@@ -245,10 +251,11 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
   List<Widget> _buildSpiderfyCluster(MarkerClusterNode cluster, int? zoom) {
     final pos = _getPixelFromCluster(cluster);
 
-    final points =
-        _generatePointSpiderfy(cluster.markers.length, _getPixelFromPoint(cluster.point));
+    final points = _generatePointSpiderfy(
+        cluster.markers.length, _getPixelFromPoint(cluster.point));
 
-    final fadeAnimation = Tween<double>(begin: 1.0, end: 0.3).animate(_spiderfyController);
+    final fadeAnimation =
+        Tween<double>(begin: 1.0, end: 0.3).animate(_spiderfyController);
 
     var results = <Widget>[];
 
@@ -298,9 +305,10 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
   List<Marker> getClusterMarkers(MarkerClusterNode cluster) =>
       cluster.markers.map((node) => node.marker).toList();
 
-  Size getClusterSize(MarkerClusterNode cluster) => widget.options.computeSize == null
-      ? widget.options.size
-      : widget.options.computeSize!(getClusterMarkers(cluster));
+  Size getClusterSize(MarkerClusterNode cluster) =>
+      widget.options.computeSize == null
+          ? widget.options.size
+          : widget.options.computeSize!(getClusterMarkers(cluster));
 
   Widget _buildCluster(MarkerClusterNode cluster,
       [FadeType fade = FadeType.None,
@@ -312,7 +320,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
     final pos = _getPixelFromCluster(cluster);
 
     var fadeAnimation = _fadeAnimation(_zoomController, fade);
-    var translateAnimation = _translateAnimation(_zoomController, translate, pos, newPos);
+    var translateAnimation =
+        _translateAnimation(_zoomController, translate, pos, newPos);
 
     var size = getClusterSize(cluster);
 
@@ -360,23 +369,26 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
   void _unspiderfy() {
     switch (_spiderfyController.status) {
       case AnimationStatus.completed:
-        var markersGettingClustered =
-            _spiderfyCluster!.markers.map((markerNode) => markerNode.marker).toList();
+        var markersGettingClustered = _spiderfyCluster!.markers
+            .map((markerNode) => markerNode.marker)
+            .toList();
 
         _spiderfyController.reverse().then((_) => setState(() {
               _spiderfyCluster = null;
             }));
 
         if (widget.options.popupOptions != null) {
-          widget.options.popupOptions!.popupController.hidePopupsOnlyFor(markersGettingClustered);
+          widget.options.popupOptions!.popupController
+              .hidePopupsOnlyFor(markersGettingClustered);
         }
         if (widget.options.onMarkersClustered != null) {
           widget.options.onMarkersClustered!(markersGettingClustered);
         }
         break;
       case AnimationStatus.forward:
-        var markersGettingClustered =
-            _spiderfyCluster!.markers.map((markerNode) => markerNode.marker).toList();
+        var markersGettingClustered = _spiderfyCluster!.markers
+            .map((markerNode) => markerNode.marker)
+            .toList();
 
         _spiderfyController
           ..stop()
@@ -385,7 +397,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
               }));
 
         if (widget.options.popupOptions != null) {
-          widget.options.popupOptions!.popupController.hidePopupsOnlyFor(markersGettingClustered);
+          widget.options.popupOptions!.popupController
+              .hidePopupsOnlyFor(markersGettingClustered);
         }
         if (widget.options.onMarkersClustered != null) {
           widget.options.onMarkersClustered!(markersGettingClustered);
@@ -433,10 +446,15 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
       // animating and
       // zoom in and parent has the previous zoom
       if (_zoomController.isAnimating &&
-          (_currentZoom > _previousZoom && layer.parent!.zoom == _previousZoom)) {
+          (_currentZoom > _previousZoom &&
+              layer.parent!.zoom == _previousZoom)) {
         // marker
-        layers.add(_buildMarker(layer, _zoomController, FadeType.FadeIn,
-            TranslateType.FromNewPosToMyPos, _getPixelFromMarker(layer, layer.parent!.point)));
+        layers.add(_buildMarker(
+            layer,
+            _zoomController,
+            FadeType.FadeIn,
+            TranslateType.FromNewPosToMyPos,
+            _getPixelFromMarker(layer, layer.parent!.point)));
         //parent
         layers.add(_buildCluster(layer.parent!, FadeType.FadeOut));
       } else {
@@ -461,24 +479,36 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
           if (child is MarkerNode) {
             markersGettingClustered.add(child.marker);
 
-            layers.add(_buildMarker(child, _zoomController, FadeType.FadeOut,
-                TranslateType.FromMyPosToNewPos, _getPixelFromMarker(child, layer.point)));
+            layers.add(_buildMarker(
+                child,
+                _zoomController,
+                FadeType.FadeOut,
+                TranslateType.FromMyPosToNewPos,
+                _getPixelFromMarker(child, layer.point)));
           } else {
-            layers.add(_buildCluster(child, FadeType.FadeOut, TranslateType.FromMyPosToNewPos,
+            layers.add(_buildCluster(
+                child,
+                FadeType.FadeOut,
+                TranslateType.FromMyPosToNewPos,
                 _getPixelFromCluster(child, layer.point)));
           }
         });
 
         if (widget.options.popupOptions != null) {
-          widget.options.popupOptions!.popupController.hidePopupsOnlyFor(markersGettingClustered);
+          widget.options.popupOptions!.popupController
+              .hidePopupsOnlyFor(markersGettingClustered);
         }
         if (widget.options.onMarkersClustered != null) {
           widget.options.onMarkersClustered!(markersGettingClustered);
         }
       } else if (_zoomController.isAnimating &&
-          (_currentZoom > _previousZoom && layer.parent!.point != layer.point)) {
+          (_currentZoom > _previousZoom &&
+              layer.parent!.point != layer.point)) {
         // cluster
-        layers.add(_buildCluster(layer, FadeType.FadeIn, TranslateType.FromNewPosToMyPos,
+        layers.add(_buildCluster(
+            layer,
+            FadeType.FadeIn,
+            TranslateType.FromNewPosToMyPos,
             _getPixelFromCluster(layer, layer.parent!.point)));
         //parent
         layers.add(_buildCluster(layer.parent!, FadeType.FadeOut));
@@ -518,7 +548,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
             })); // for remove previous layer (animation)
     }
 
-    _topClusterLevel.recursively(_currentZoom, widget.options.disableClusteringAtZoom, (layer) {
+    _topClusterLevel.recursively(
+        _currentZoom, widget.options.disableClusteringAtZoom, (layer) {
       layers.addAll(_buildLayer(layer));
     });
 
@@ -560,7 +591,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
 
       // check if children can un-cluster
       final cannotDivide = cluster.markers.every((marker) =>
-          marker.parent!.zoom == _maxZoom && marker.parent == cluster.markers[0].parent);
+          marker.parent!.zoom == _maxZoom &&
+          marker.parent == cluster.markers[0].parent);
       if (cannotDivide) {
         _spiderfy(cluster);
         return null;
@@ -568,11 +600,12 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
 
       if (!widget.options.zoomToBoundsOnClick) return null;
 
-      _showPolygon(
-          cluster.markers.fold<List<LatLng>>([], (result, marker) => result..add(marker.point)));
+      _showPolygon(cluster.markers.fold<List<LatLng>>(
+          [], (result, marker) => result..add(marker.point)));
 
       final center = widget.map.center;
-      var dest = widget.map.getBoundsCenterZoom(cluster.bounds, widget.options.fitBoundsOptions);
+      var dest = widget.map
+          .getBoundsCenterZoom(cluster.bounds, widget.options.fitBoundsOptions);
 
       // Force a jump to the next zoom level if that wouldn't otherwise occur.
       if (dest.zoom < cluster.zoom) {
@@ -581,15 +614,21 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
           zoom: cluster.zoom.toDouble() + 0.0000000001,
         );
       }
-      final _latTween = Tween<double>(begin: center.latitude, end: dest.center.latitude);
-      final _lngTween = Tween<double>(begin: center.longitude, end: dest.center.longitude);
-      final _zoomTween = Tween<double>(begin: _currentZoom.toDouble(), end: dest.zoom);
+      final _latTween =
+          Tween<double>(begin: center.latitude, end: dest.center.latitude);
+      final _lngTween =
+          Tween<double>(begin: center.longitude, end: dest.center.longitude);
+      final _zoomTween =
+          Tween<double>(begin: _currentZoom.toDouble(), end: dest.zoom);
 
       Animation<double> animation = CurvedAnimation(
-          parent: _fitBoundController, curve: widget.options.animationsOptions.fitBoundCurves);
+          parent: _fitBoundController,
+          curve: widget.options.animationsOptions.fitBoundCurves);
 
       final listener = () {
-        widget.map.move(LatLng(_latTween.evaluate(animation), _lngTween.evaluate(animation)),
+        widget.map.move(
+            LatLng(
+                _latTween.evaluate(animation), _lngTween.evaluate(animation)),
             _zoomTween.evaluate(animation),
             source: MapEventSource.custom);
       };
@@ -611,7 +650,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
           PolygonLayerOptions(polygons: [
             Polygon(
               points: QuickHull.getConvexHull(points),
-              borderStrokeWidth: widget.options.polygonOptions.borderStrokeWidth,
+              borderStrokeWidth:
+                  widget.options.polygonOptions.borderStrokeWidth,
               color: widget.options.polygonOptions.color,
               borderColor: widget.options.polygonOptions.borderColor,
               isDotted: widget.options.polygonOptions.isDotted,
@@ -640,7 +680,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
 
       if (widget.options.popupOptions != null) {
         final popupOptions = widget.options.popupOptions!;
-        popupOptions.markerTapBehavior.apply(marker.marker, popupOptions.popupController);
+        popupOptions.markerTapBehavior
+            .apply(marker.marker, popupOptions.popupController);
       }
 
       // This is handled as an optional callback rather than leaving the package
@@ -655,8 +696,10 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
 
       final center = widget.map.center;
 
-      final _latTween = Tween<double>(begin: center.latitude, end: marker.point.latitude);
-      final _lngTween = Tween<double>(begin: center.longitude, end: marker.point.longitude);
+      final _latTween =
+          Tween<double>(begin: center.latitude, end: marker.point.latitude);
+      final _lngTween =
+          Tween<double>(begin: center.longitude, end: marker.point.longitude);
 
       Animation<double> animation = CurvedAnimation(
           parent: _centerMarkerController,
@@ -664,7 +707,9 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
 
       final listener = () {
         widget.map.move(
-            LatLng(_latTween.evaluate(animation), _lngTween.evaluate(animation)), widget.map.zoom,
+            LatLng(
+                _latTween.evaluate(animation), _lngTween.evaluate(animation)),
+            widget.map.zoom,
             source: MapEventSource.custom);
       };
 
@@ -683,7 +728,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProv
       return widget.options.spiderfyShapePositions!(count, center);
     }
     if (count >= widget.options.circleSpiralSwitchover) {
-      return Spiderfy.spiral(widget.options.spiderfySpiralDistanceMultiplier, count, center);
+      return Spiderfy.spiral(
+          widget.options.spiderfySpiralDistanceMultiplier, count, center);
     }
 
     return Spiderfy.circle(widget.options.spiderfyCircleRadius, count, center);

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -74,11 +74,12 @@ class PopupOptions {
     this.popupAnimation,
     this.markerRotate = false,
     MarkerTapBehavior? markerTapBehavior,
-  })  : markerTapBehavior = markerTapBehavior ?? MarkerTapBehavior.togglePopupAndHideRest(),
+  }) : markerTapBehavior = markerTapBehavior ?? MarkerTapBehavior.togglePopupAndHideRest(),
         popupController = popupController ?? PopupController();
 }
 
-typedef ClusterWidgetBuilder = Widget Function(BuildContext context, List<Marker> markers);
+typedef ClusterWidgetBuilder = Widget Function(
+    BuildContext context, List<Marker> markers);
 
 class MarkerClusterLayerOptions extends LayerOptions {
   /// Cluster builder
@@ -181,7 +182,8 @@ class MarkerClusterLayerOptions extends LayerOptions {
     this.maxClusterRadius = 80,
     this.disableClusteringAtZoom = 20,
     this.animationsOptions = const AnimationsOptions(),
-    this.fitBoundsOptions = const FitBoundsOptions(padding: EdgeInsets.all(12.0)),
+    this.fitBoundsOptions =
+        const FitBoundsOptions(padding: EdgeInsets.all(12.0)),
     this.zoomToBoundsOnClick = true,
     this.centerMarkerOnClick = true,
     this.spiderfyCircleRadius = 40,


### PR DESCRIPTION
The code for countering map rotation was copied directly from the official flutter_map repo. I believe that it is desired to mimic the same behavior as with the official MarkerLayerOptions.

I also observed, that if the key is passed to the Marker, it is not used when building the widget. Therefore it was impossible to retain the state of the marker widget.