### PR TITLE
Regression: flutter_map_marker_popup: 2.1.0 breaks the lib

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_map: ">=0.13.1 <1.0.0"
   latlong2: ^0.8.0
-  flutter_map_marker_popup: ^2.0.0
+  flutter_map_marker_popup: 2.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
`flutter_map_marker_popup` has just been updated to `2.1.0`. 
There are some changes there incompatible with the current code. 

I propose rolling back the version of `flutter_map_marker_popup` to the last working minor release.