### PR TITLE
Ability to customize the spiderfy animation

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -255,12 +255,16 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     final points = _generatePointSpiderfy(
         cluster.markers.length, _getPixelFromPoint(cluster.point));
 
-    final fadeAnimation =
-        Tween<double>(begin: 1.0, end: 0.3).animate(_spiderfyController);
+    final fadeAnimation = (widget.options.animationsOptions.spiderfyTween ??
+            Tween<double>(begin: 1.0, end: 0.3))
+        .animate(_spiderfyController);
 
     var results = <Widget>[];
 
     var size = getClusterSize(cluster);
+
+    final builder = widget.options.animationsOptions.spiderfyAnimationBuilder ??
+        _defaultSpiderfyAnimationBuilder;
 
     results.add(
       AnimatedBuilder(
@@ -271,10 +275,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
             height: size.height,
             left: pos.x as double?,
             top: pos.y as double?,
-            child: Opacity(
-              opacity: fadeAnimation.value,
-              child: child,
-            ),
+            child: builder(context, fadeAnimation, cluster, child),
           );
         },
         child: GestureDetector(
@@ -301,6 +302,15 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     }
 
     return results;
+  }
+
+  static Widget _defaultSpiderfyAnimationBuilder(
+    BuildContext context,
+    Animation<double> animation,
+    MarkerClusterNode node,
+    Widget? child,
+  ) {
+    return Opacity(opacity: animation.value, child: child);
   }
 
   List<Marker> getClusterMarkers(MarkerClusterNode cluster) =>

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -21,6 +21,13 @@ class PolygonOptions {
   });
 }
 
+typedef SpiderfyAnimationBuilder = Widget Function(
+  BuildContext context,
+  Animation<double> animation,
+  MarkerClusterNode node,
+  Widget? child,
+);
+
 class AnimationsOptions {
   final Duration zoom;
   final Duration fitBound;
@@ -28,12 +35,16 @@ class AnimationsOptions {
   final Duration centerMarker;
   final Curve centerMarkerCurves;
   final Duration spiderfy;
+  final SpiderfyAnimationBuilder? spiderfyAnimationBuilder;
+  final Tween<double>? spiderfyTween;
 
   const AnimationsOptions({
     this.zoom = const Duration(milliseconds: 500),
     this.fitBound = const Duration(milliseconds: 500),
     this.centerMarker = const Duration(milliseconds: 500),
     this.spiderfy = const Duration(milliseconds: 500),
+    this.spiderfyAnimationBuilder,
+    this.spiderfyTween,
     this.fitBoundCurves = Curves.fastOutSlowIn,
     this.centerMarkerCurves = Curves.fastOutSlowIn,
   });


### PR DESCRIPTION
Hi!

I was looking for some way to customize the appearance of the cluster marker when spiderfied but have found it's all hardcoded. While it was trivial to fork and replace this code with something that fulfills my requirements, I thought it would be valuable to others to make the marker customizable with a builder.

This pull request contains additional options in `AnimationsOptions`, when not set, the current behavior with opacity animation is maintained. But with `spiderfyAnimationBuilder` you can replace it with anything else. The function takes `child` argument which is the original cluster marker widget and `animation` which is by default a tween from 1.0 to 0.3 like it was hardcoded before, and also `MarkerClusterNode node` for more complex use cases that involve building the widget based on the marker data. Also, the default tween can be replaced with `spiderfyTween` option.

Please let me know what do you think of this.