### PR TITLE
prevent flickering when marker list changes

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -175,6 +175,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
               alignment:
                   marker.rotateAlignment ?? widget.options.rotateAlignment,
             ),
+      key: marker.key ?? ObjectKey(marker.marker),
       child: MarkerWidget(
         marker: marker,
         onTap: _onMarkerTap(marker),


### PR DESCRIPTION

When the list of markers changes, i.e. the order of elements changes or some elements are added/removed, the state of one marker widget might get matched to another marker, resulting in a loss of state for that widget. When working with FutureBuilder or StreamBuilder's for example this might result in flickering. 

This merge request solves this by setting a key to the MapWidget's.