### PR TITLE
Use the marker's key to avoid rebuilding

### DIFF
--- a/lib/src/marker_widget.dart
+++ b/lib/src/marker_widget.dart
@@ -14,7 +14,7 @@ class MarkerWidget extends StatelessWidget {
     this.onHover,
     this.buildOnHover = false,
     this.hoverOnTap,
-  }) : super(key: ObjectKey(marker));
+  }) : super(key: marker.key ?? ObjectKey(marker.marker));
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
The current behavior is that, when the marker list changes, all marker widgets are rebuilt without any state sharing. This is because the `MarkerWidget` uses an `ObjectKey` on the `MarkerNode`, which is always created anew.

The `MapWidget` is currently constructed with this a key as proposed in this change. I can't think of a reason why `MarkerWidget` should be different.