### PR TITLE
Performance: almost 90% reduction in Widget build times

### DIFF
--- a/lib/src/cluster_manager.dart
+++ b/lib/src/cluster_manager.dart
@@ -68,8 +68,7 @@ class ClusterManager {
 
   bool isSpiderfyCluster(MarkerClusterNode cluster) {
     return spiderfyCluster != null &&
-        spiderfyCluster!.bounds.center ==
-            cluster.bounds.center;
+        spiderfyCluster!.bounds.center == cluster.bounds.center;
   }
 
   void addLayer(MarkerNode marker, int disableClusteringAtZoom, int maxZoom,
@@ -152,10 +151,14 @@ class ClusterManager {
     }
   }
 
-  void recalculateTopClusterLevelBounds() =>
-      _topClusterLevel.recalculateBounds();
+  void recalculateTopClusterLevelProperties() =>
+      _topClusterLevel.recalculateBoundsRecursively();
 
-  void recursivelyFromTopClusterLevel(int? zoomLevel,
-          int disableClusteringAtZoom, Function(MarkerOrClusterNode) fn) =>
-      _topClusterLevel.recursively(zoomLevel, disableClusteringAtZoom, fn);
+  void recursivelyFromTopClusterLevel(
+          int zoomLevel,
+          int disableClusteringAtZoom,
+          LatLngBounds recursionBounds,
+          Function(MarkerOrClusterNode) fn) =>
+      _topClusterLevel.recursively(
+          zoomLevel, disableClusteringAtZoom, recursionBounds, fn);
 }

--- a/lib/src/cluster_manager.dart
+++ b/lib/src/cluster_manager.dart
@@ -68,8 +68,8 @@ class ClusterManager {
 
   bool isSpiderfyCluster(MarkerClusterNode cluster) {
     return spiderfyCluster != null &&
-        mapCalculator.clusterPoint(spiderfyCluster!) ==
-            mapCalculator.clusterPoint(cluster);
+        spiderfyCluster!.bounds.center ==
+            cluster.bounds.center;
   }
 
   void addLayer(MarkerNode marker, int disableClusteringAtZoom, int maxZoom,
@@ -102,7 +102,7 @@ class ClusterManager {
           _gridClusters[zoom]!.addObject(
             newCluster,
             mapCalculator.project(
-              mapCalculator.clusterPoint(newCluster),
+              newCluster.bounds.center,
               zoom: zoom.toDouble(),
             ),
           );
@@ -118,7 +118,7 @@ class ClusterManager {
             );
             newParent.addChild(
               lastParent,
-              mapCalculator.clusterPoint(lastParent),
+              lastParent.bounds.center,
             );
             lastParent = newParent;
             _gridClusters[z]!.addObject(
@@ -129,7 +129,7 @@ class ClusterManager {
               ),
             );
           }
-          parent.addChild(lastParent, mapCalculator.clusterPoint(lastParent));
+          parent.addChild(lastParent, lastParent.bounds.center);
 
           _removeFromNewPosToMyPosGridUnclustered(closest, zoom, minZoom);
           return;

--- a/lib/src/map_calculator.dart
+++ b/lib/src/map_calculator.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_map/plugin_api.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_cluster_node.dart';
-import 'package:flutter_map_marker_cluster/src/node/marker_node.dart';
 import 'package:latlong2/latlong.dart';
 
 class MapCalculator {
@@ -10,50 +9,7 @@ class MapCalculator {
 
   CustomPoint<num> getPixelFromPoint(LatLng point) {
     final pos = mapState.project(point);
-    return pos.multiplyBy(mapState.getZoomScale(mapState.zoom, mapState.zoom)) -
-        mapState.pixelOrigin;
-  }
-
-  bool boundsContainsMarker(MarkerNode marker) {
-    return _boundsContains(
-      mapState.project(marker.point),
-      marker.width,
-      marker.height,
-      marker.anchor,
-    );
-  }
-
-  LatLng clusterPoint(MarkerClusterNode cluster) {
-    final swPoint = project(cluster.bounds.southWest!);
-    final nePoint = project(cluster.bounds.northEast!);
-    return unproject((swPoint + nePoint) / 2);
-  }
-
-  bool boundsContainsCluster(MarkerClusterNode cluster) {
-    final pixelPoint = mapState.project(clusterPoint(cluster));
-    final size = cluster.size();
-    final anchor = Anchor.forPos(cluster.anchorPos, size.width, size.height);
-
-    return _boundsContains(pixelPoint, size.width, size.height, anchor);
-  }
-
-  bool _boundsContains(
-    CustomPoint pixelPoint,
-    double width,
-    double height,
-    Anchor anchor,
-  ) {
-    final rightPortion = width - anchor.left;
-    final leftPortion = anchor.left;
-    final bottomPortion = height - anchor.top;
-    final topPortion = anchor.top;
-
-    final sw =
-        CustomPoint(pixelPoint.x + leftPortion, pixelPoint.y - bottomPortion);
-    final ne =
-        CustomPoint(pixelPoint.x - rightPortion, pixelPoint.y + topPortion);
-
-    return mapState.pixelBounds.containsPartialBounds(Bounds(sw, ne));
+    return pos.multiplyBy(mapState.getZoomScale(mapState.zoom, mapState.zoom)) - mapState.pixelOrigin;
   }
 
   CustomPoint project(LatLng latLng, {double? zoom}) =>

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -264,35 +264,19 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     }
   }
 
-  List<Widget> _buildLayer(MarkerOrClusterNode layer) {
-    if (layer is MarkerNode) {
-      return _buildMarkerLayer(layer);
-    } else if (layer is MarkerClusterNode) {
-      return _buildMarkerClusterLayer(layer);
-    } else {
-      throw 'Unexpected layer type: ${layer.runtimeType}';
-    }
-  }
-
-  List<Widget> _buildMarkerLayer(MarkerNode markerNode) {
-    if (!_mapCalculator.boundsContainsMarker(markerNode)) return <Widget>[];
-
+  void _addMarkerLayer(MarkerNode markerNode, List<Widget> layers) {
     if (_zoomingIn && markerNode.parent!.zoom == _previousZoom) {
-      return _buildZoomingInMarkerLayer(markerNode);
+      _addZoomingInMarkerLayer(markerNode, layers);
     } else {
-      return [
-        _buildMarker(
-          marker: markerNode,
-          controller: _zoomController,
-          translate: StaticTranslate(_mapCalculator, markerNode),
-        ),
-      ];
+      layers.add(_buildMarker(
+        marker: markerNode,
+        controller: _zoomController,
+        translate: StaticTranslate(_mapCalculator, markerNode),
+      ));
     }
   }
 
-  List<Widget> _buildZoomingInMarkerLayer(MarkerNode markerNode) {
-    final layers = <Widget>[];
-
+  void _addZoomingInMarkerLayer(MarkerNode markerNode, List<Widget> layers) {
     layers.add(
       _buildMarker(
         marker: markerNode,
@@ -320,20 +304,15 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         ),
       ),
     );
-
-    return layers;
   }
 
-  List<Widget> _buildMarkerClusterLayer(MarkerClusterNode clusterNode) {
-    final layers = <Widget>[];
-    if (!_mapCalculator.boundsContainsCluster(clusterNode)) return layers;
-
+  void _addMarkerClusterLayer(
+      MarkerClusterNode clusterNode, List<Widget> layers) {
     if (_zoomingOut && clusterNode.children.length > 1) {
-      return _buildClusterClosingLayer(clusterNode);
+      _addClusterClosingLayer(clusterNode, layers);
     } else if (_zoomingIn &&
-        _mapCalculator.clusterPoint(clusterNode.parent!) !=
-            _mapCalculator.clusterPoint(clusterNode)) {
-      return _buildClusterOpeningLayer(clusterNode);
+        clusterNode.parent!.bounds.center != clusterNode.bounds.center) {
+      _addClusterOpeningLayer(clusterNode, layers);
     } else if (_clusterManager.isSpiderfyCluster(clusterNode)) {
       layers.addAll(_buildSpiderfyCluster(clusterNode, _currentZoom));
     } else {
@@ -349,13 +328,10 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         ),
       );
     }
-
-    return layers;
   }
 
-  List<Widget> _buildClusterClosingLayer(MarkerClusterNode clusterNode) {
-    final layers = <Widget>[];
-
+  void _addClusterClosingLayer(
+      MarkerClusterNode clusterNode, List<Widget> layers) {
     // cluster
     layers.add(
       MapWidget(
@@ -415,41 +391,38 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       markersGettingClustered,
     );
     widget.options.onMarkersClustered?.call(markersGettingClustered);
-
-    return layers;
   }
 
-  List<Widget> _buildClusterOpeningLayer(MarkerClusterNode clusterNode) {
-    return <Widget>[
-      // cluster
-      MapWidget(
-        size: clusterNode.size(),
-        animationController: _zoomController,
-        translate: AnimatedTranslate.fromNewPosToMyPos(
-          mapCalculator: _mapCalculator,
-          from: clusterNode,
-          to: clusterNode.parent!,
-        ),
-        fade: Fade.fadeIn,
-        child: ClusterWidget(
-          cluster: clusterNode,
-          builder: widget.options.builder,
-          onTap: _onClusterTap(clusterNode),
-        ),
+  void _addClusterOpeningLayer(
+      MarkerClusterNode clusterNode, List<Widget> layers) {
+    // cluster
+    layers.add(MapWidget(
+      size: clusterNode.size(),
+      animationController: _zoomController,
+      translate: AnimatedTranslate.fromNewPosToMyPos(
+        mapCalculator: _mapCalculator,
+        from: clusterNode,
+        to: clusterNode.parent!,
       ),
-      //parent
-      MapWidget(
-        size: clusterNode.parent!.size(),
-        animationController: _zoomController,
-        translate: StaticTranslate(_mapCalculator, clusterNode.parent!),
-        fade: Fade.fadeOut,
-        child: ClusterWidget(
-          cluster: clusterNode.parent!,
-          builder: widget.options.builder,
-          onTap: _onClusterTap(clusterNode.parent!),
-        ),
+      fade: Fade.fadeIn,
+      child: ClusterWidget(
+        cluster: clusterNode,
+        builder: widget.options.builder,
+        onTap: _onClusterTap(clusterNode),
       ),
-    ];
+    ));
+    //parent
+    layers.add(MapWidget(
+      size: clusterNode.parent!.size(),
+      animationController: _zoomController,
+      translate: StaticTranslate(_mapCalculator, clusterNode.parent!),
+      fade: Fade.fadeOut,
+      child: ClusterWidget(
+        cluster: clusterNode.parent!,
+        builder: widget.options.builder,
+        onTap: _onClusterTap(clusterNode.parent!),
+      ),
+    ));
   }
 
   List<Widget> _buildSpiderfyCluster(
@@ -472,9 +445,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     );
     final points = _generatePointSpiderfy(
       cluster.markers.length,
-      _mapCalculator.getPixelFromPoint(
-        _mapCalculator.clusterPoint(cluster),
-      ),
+      _mapCalculator.getPixelFromPoint(cluster.bounds.center),
     );
 
     for (var i = 0; i < cluster.markers.length; i++) {
@@ -524,7 +495,22 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     _clusterManager.recursivelyFromTopClusterLevel(
         _currentZoom, widget.options.disableClusteringAtZoom,
         (MarkerOrClusterNode layer) {
-      layers.addAll(_buildLayer(layer));
+      // This is the performance critical hoth path recursed on every map
+      // event!
+
+      // Cull markers/clusters that are not on screen.
+      final map = _mapCalculator.mapState;
+      if (!map.pixelBounds.containsPartialBounds(layer.pixelBounds(map))) {
+        return;
+      }
+
+      if (layer is MarkerNode) {
+        _addMarkerLayer(layer, layers);
+      } else if (layer is MarkerClusterNode) {
+        _addMarkerClusterLayer(layer, layers);
+      } else {
+        throw 'Unexpected layer type: ${layer.runtimeType}';
+      }
     });
 
     final popupOptions = widget.options.popupOptions;
@@ -572,7 +558,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       // check if children can un-cluster
       final cannotDivide = cluster.markers.every((marker) =>
               marker.parent!.zoom == _maxZoom &&
-              marker.parent == cluster.markers[0].parent) ||
+              marker.parent == cluster.markers.first.parent) ||
           (dest.zoom == _currentZoom &&
               _currentZoom == widget.options.fitBoundsOptions.maxZoom);
 
@@ -590,12 +576,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       }
 
       if (dest.zoom > _currentZoom && !cannotDivide) {
-        _showPolygon(
-          cluster.markers.fold<List<LatLng>>(
-            [],
-            (result, marker) => result..add(marker.point),
-          ),
-        );
+        _showPolygon(cluster.markers.map((m) => m.point).toList());
       }
 
       final latTween =

--- a/lib/src/marker_widget.dart
+++ b/lib/src/marker_widget.dart
@@ -18,15 +18,18 @@ class MarkerWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: buildOnHover && hoverOnTap != null ? hoverOnTap : onTap,
-        child: buildOnHover && onHover != null
-            ? MouseRegion(
-                onEnter: (_) => onHover!(true),
-                onExit: (_) => onHover!(false),
-                child: marker.builder(context),
-              )
-            : marker.builder(context));
+    final m = marker.builder(context);
+    return buildOnHover
+        ? GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: hoverOnTap ?? onTap,
+            child: onHover != null
+                ? MouseRegion(
+                    onEnter: (_) => onHover!(true),
+                    onExit: (_) => onHover!(false),
+                    child: m,
+                  )
+                : m)
+        : m;
   }
 }

--- a/lib/src/node/marker_cluster_node.dart
+++ b/lib/src/node/marker_cluster_node.dart
@@ -6,42 +6,57 @@ import 'package:flutter_map_marker_cluster/src/node/marker_node.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_or_cluster_node.dart';
 import 'package:latlong2/latlong.dart';
 
+class _Derived {
+  final markerNodes = <MarkerNode>[];
+  final bounds = LatLngBounds();
+  late final List<Marker> markers;
+  late final Size? size;
+
+  _Derived(List<MarkerOrClusterNode> children,
+      Size Function(List<Marker>)? computeSize) {
+    markerNodes.addAll(children.whereType<MarkerNode>());
+    for (final child in children) {
+      if (child is MarkerClusterNode) {
+        markerNodes.addAll(child.markers);
+      }
+    }
+
+    for (final marker in markerNodes) {
+      bounds.extend(marker.point);
+    }
+
+    markers = markerNodes.map((m) => m.marker).toList();
+    size = (computeSize != null) ? computeSize(markers) : null;
+  }
+}
+
 class MarkerClusterNode extends MarkerOrClusterNode {
   final int zoom;
   final AnchorPos? anchorPos;
   final Size predefinedSize;
   final Size Function(List<Marker>)? computeSize;
-  final List<MarkerOrClusterNode> children;
-  LatLngBounds bounds;
-  int? addCount;
-  int? removeCount;
+  final children = <MarkerOrClusterNode>[];
 
-  List<MarkerNode> get markers {
-    final markers = <MarkerNode>[];
+  late _Derived _derived;
 
-    markers.addAll(children.whereType<MarkerNode>());
-
-    for (final child in children) {
-      if (child is MarkerClusterNode) {
-        markers.addAll(child.markers);
-      }
-    }
-    return markers;
-  }
+  List<MarkerNode> get markers => _derived.markerNodes;
+  LatLngBounds get bounds => _derived.bounds;
+  List<Marker> get mapMarkers => _derived.markers;
+  Size size() => _derived.size ?? predefinedSize;
 
   MarkerClusterNode({
     required this.zoom,
     required this.anchorPos,
     required this.predefinedSize,
     this.computeSize,
-  })  : bounds = LatLngBounds(),
-        children = [],
-        super(parent: null);
+  }) : super(parent: null) {
+    _derived = _Derived(children, computeSize);
+  }
 
   void addChild(MarkerOrClusterNode child, LatLng childPoint) {
     children.add(child);
     child.parent = this;
-    bounds.extend(childPoint);
+    recalculateBounds();
   }
 
   void removeChild(MarkerOrClusterNode child) {
@@ -50,17 +65,7 @@ class MarkerClusterNode extends MarkerOrClusterNode {
   }
 
   void recalculateBounds() {
-    bounds = LatLngBounds();
-
-    for (final marker in markers) {
-      bounds.extend(marker.point);
-    }
-
-    for (final child in children) {
-      if (child is MarkerClusterNode) {
-        child.recalculateBounds();
-      }
-    }
+    _derived = _Derived(children, computeSize);
   }
 
   void recursively(
@@ -76,14 +81,28 @@ class MarkerClusterNode extends MarkerOrClusterNode {
     for (final child in children) {
       if (child is MarkerNode) {
         fn(child);
-      }
-      if (child is MarkerClusterNode) {
+      } else if (child is MarkerClusterNode) {
         child.recursively(zoomLevel, disableClusteringAtZoom, fn);
       }
     }
   }
 
-  List<Marker> get mapMarkers => markers.map((node) => node.marker).toList();
+  @override
+  Bounds pixelBounds(FlutterMapState map) {
+    final width = size().width;
+    final height = size().height;
+    final anchor = Anchor.forPos(anchorPos, width, height);
 
-  Size size() => computeSize?.call(mapMarkers) ?? predefinedSize;
+    final rightPortion = width - anchor.left;
+    final leftPortion = anchor.left;
+    final bottomPortion = height - anchor.top;
+    final topPortion = anchor.top;
+
+    final ne =
+        map.project(bounds.northEast!) + CustomPoint(rightPortion, -topPortion);
+    final sw = map.project(bounds.southWest!) +
+        CustomPoint(-leftPortion, bottomPortion);
+
+    return Bounds(ne, sw);
+  }
 }

--- a/lib/src/node/marker_node.dart
+++ b/lib/src/node/marker_node.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map/plugin_api.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_or_cluster_node.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -34,4 +34,21 @@ class MarkerNode extends MarkerOrClusterNode implements Marker {
 
   @override
   Offset? get rotateOrigin => marker.rotateOrigin;
+
+  @override
+  Bounds pixelBounds(FlutterMapState map) {
+    final pixelPoint = map.project(point);
+
+    final rightPortion = width - anchor.left;
+    final leftPortion = anchor.left;
+    final bottomPortion = height - anchor.top;
+    final topPortion = anchor.top;
+
+    final ne =
+        CustomPoint(pixelPoint.x - rightPortion, pixelPoint.y + topPortion);
+    final sw =
+        CustomPoint(pixelPoint.x + leftPortion, pixelPoint.y - bottomPortion);
+
+    return Bounds(ne, sw);
+  }
 }

--- a/lib/src/node/marker_or_cluster_node.dart
+++ b/lib/src/node/marker_or_cluster_node.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_map/plugin_api.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_cluster_node.dart';
 
 /// Just a base class which MarkerNode and MarkerClusterNode both extend which
@@ -7,4 +8,6 @@ abstract class MarkerOrClusterNode {
   MarkerClusterNode? parent;
 
   MarkerOrClusterNode({required this.parent});
+
+  Bounds pixelBounds(FlutterMapState map);
 }

--- a/lib/src/translate.dart
+++ b/lib/src/translate.dart
@@ -49,7 +49,7 @@ abstract class Translate {
     LatLng? customPoint,
   }) {
     final pos = mapCalculator.getPixelFromPoint(
-        customPoint ?? mapCalculator.clusterPoint(clusterNode));
+        customPoint ?? clusterNode.bounds.center);
 
     final calculatedSize = clusterNode.size();
     final anchor = Anchor.forPos(
@@ -94,7 +94,7 @@ class AnimatedTranslate extends Translate {
         newPosition = Translate._getNodePixel(
           mapCalculator,
           from,
-          customPoint: mapCalculator.clusterPoint(to),
+          customPoint: to.bounds.center,
         ) {
     _tween = Tween<Point<double>>(
       begin: Point(position.x, position.y),
@@ -110,7 +110,7 @@ class AnimatedTranslate extends Translate {
         newPosition = Translate._getNodePixel(
           mapCalculator,
           from,
-          customPoint: mapCalculator.clusterPoint(to),
+          customPoint: to.bounds.center,
         ) {
     _tween = Tween<Point<double>>(
       begin: Point(newPosition.x, newPosition.y),
@@ -126,7 +126,7 @@ class AnimatedTranslate extends Translate {
   })  : position = Translate._getMarkerPixel(
           mapCalculator,
           marker,
-          customPoint: mapCalculator.clusterPoint(cluster),
+          customPoint: cluster.bounds.center,
         ),
         newPosition = util.removeAnchor(
           point,


### PR DESCRIPTION
I noticed that for my use-cases I was bottle-necked by UI-thread utilization, frequently missing the 60FPS mark and starving the rasterization pipeline.

At first I took a stab with the profiler and did some micro-optimizations with some small success (though hope the code got a bit simpler too). Afterwards, I realized that the node-trees geographical partitioning is greatly suited to reduce the amount of work that needs to be done. Today, we're going though all markers to then cull them if they're not on screen. However we can dismiss entire clusters early.

Measured widget build times:
 * Before: 1446.1636363636364 +/- 480.1128944372966
 * After:  1453.418181818182 +/- 336.8953811663788

i.e. a 87% reduction. However, looking at the performance overlay implies the impact is even larger (inline with what I experienced with the micro-optimizations).

* Before: 
![Screenshot_2023-01-01-22-16-46-98_1b269ddfa23dc77342248c30e8616ea5](https://user-images.githubusercontent.com/111986/210262390-858adb47-2008-453d-b346-794892408625.jpg)
* After:
![Screenshot_2023-01-02-18-04-46-19_1b269ddfa23dc77342248c30e8616ea5](https://user-images.githubusercontent.com/111986/210262401-db3047ac-4573-4ba1-a83f-5ec27bf345e5.jpg)

