### PR TITLE
Null safe latlngbounds

### DIFF
--- a/lib/src/cluster_manager.dart
+++ b/lib/src/cluster_manager.dart
@@ -152,7 +152,7 @@ class ClusterManager {
   }
 
   void recalculateTopClusterLevelProperties() =>
-      _topClusterLevel.recalculateBounds();
+      _topClusterLevel.recalculate(recursively: true);
 
   void recursivelyFromTopClusterLevel(
           int zoomLevel,

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -711,13 +711,16 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
 LatLngBounds _extendBounds(LatLngBounds bounds, double stickonFactor) {
   final sw = bounds.southWest;
   final ne = bounds.northEast;
-  final heightBuffer = (sw!.latitude - ne!.latitude).abs() * stickonFactor;
-  final widthBuffer = (sw.longitude - ne.longitude).abs() * stickonFactor;
+  final height = (sw!.latitude - ne!.latitude).abs() * stickonFactor;
+  final width = (sw!.longitude - ne!.longitude).abs() * stickonFactor;
 
-  final point1 = LatLng((90 + sw.latitude - heightBuffer) % 180 - 90,
-      (180 + sw.longitude - widthBuffer) % 360 - 180);
-  final point2 = LatLng((90 + ne.latitude + heightBuffer) % 180 - 90,
-      (180 + ne.longitude + widthBuffer) % 360 - 180);
+  // Clamp rather than wrap around. This function is used in the context of
+  // drawing things onto a map. Since the map renderer does't wrap maps itself,
+  // we also shouldn't wrap around the bounding boxes.
+  final point1 = LatLng((bounds.south - height).clamp(-90, 90),
+      (bounds.west - width).clamp(-180, 180));
+  final point2 = LatLng((bounds.north + height).clamp(-90, 90),
+      (bounds.east + width).clamp(-180, 180));
 
   return LatLngBounds(point1, point2);
 }

--- a/lib/src/node/marker_cluster_node.dart
+++ b/lib/src/node/marker_cluster_node.dart
@@ -8,7 +8,7 @@ import 'package:latlong2/latlong.dart';
 
 class _Derived {
   final markerNodes = <MarkerNode>[];
-  final bounds = LatLngBounds();
+  late final LatLngBounds bounds;
   late final List<Marker> markers;
   late final Size? size;
 
@@ -27,6 +27,7 @@ class _Derived {
       child.recalculate(recursively: false);
     }
 
+    bool boundsInitialized = false;
     markerNodes.addAll(children.whereType<MarkerNode>());
     for (final child in children) {
       if (child is MarkerClusterNode) {
@@ -36,12 +37,25 @@ class _Derived {
         }
 
         markerNodes.addAll(child.markers);
-        bounds.extendBounds(child.bounds);
+        if (!boundsInitialized) {
+          bounds = child.bounds;
+        } else {
+          bounds.extendBounds(child.bounds);
+        }
+        boundsInitialized = true;
       } else if (child is MarkerNode) {
-        bounds.extend(child.point);
+        if (!boundsInitialized) {
+          bounds = LatLngBounds(child.point, child.point);
+        } else {
+          bounds.extend(child.point);
+        }
+        boundsInitialized = true;
       }
     }
 
+    if (!boundsInitialized) {
+      bounds = LatLngBounds(LatLng(0, 0),LatLng(0, 0));
+    }
     markers = markerNodes.map((m) => m.marker).toList();
     size = computeSize?.call(markers);
   }


### PR DESCRIPTION
Flutter 3.2 will introduce null-safe latlngbounds, i.e. there's no longer a notion of empty bounds. This complicates our intialization a little bit because we can only set-up a minimal-single-child bound, once we iterate the bounds.