### PR TITLE
Solves inability to open popup

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -174,7 +174,6 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         onTap: _onMarkerTap(marker),
         onHover: (bool value) => _onMarkerHover(marker, value),
         buildOnHover: widget.options.popupOptions?.buildPopupOnHover ?? false,
-        hoverOnTap: () => widget.options.onMarkerTap!(marker),
       ),
     );
   }

--- a/lib/src/marker_widget.dart
+++ b/lib/src/marker_widget.dart
@@ -19,17 +19,16 @@ class MarkerWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final m = marker.builder(context);
-    return buildOnHover
-        ? GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: hoverOnTap ?? onTap,
-            child: onHover != null
-                ? MouseRegion(
-                    onEnter: (_) => onHover!(true),
-                    onExit: (_) => onHover!(false),
-                    child: m,
-                  )
-                : m)
-        : m;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: hoverOnTap ?? onTap,
+      child: onHover != null
+          ? MouseRegion(
+              onEnter: (_) => onHover!(true),
+              onExit: (_) => onHover!(false),
+              child: m,
+            )
+          : m,
+    );
   }
 }


### PR DESCRIPTION
As mentioned in https://github.com/lpongetti/flutter_map_marker_cluster/issues/153 the popup-feature is broken after 1.0.1.

This change fixes so that the popup-feature works again, however, it should be reviewed by someone with more insight on what could potentially break (possibly related to desktop usage)
