### PR TITLE
Avoid all cluster marker to be rebuild when navigating on map

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -315,6 +315,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     } else {
       layers.add(
         MapWidget.static(
+          key: ObjectKey(clusterNode),
           size: clusterNode.size(),
           translate: StaticTranslate(_mapCalculator, clusterNode),
           child: ClusterWidget(


### PR DESCRIPTION
When navigating on the map (without zoom), all marker are rebuild all the time (cf Flutter performance tab)

Add an ObjectValue as key to let framework recover the Widget and avoid to rebuild it