### PR TITLE
flutter map version 6, waiting flutter_map_popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [1.3.0] - 10/11/2023
 
+- Merge pull request #188 from altotunchitoo:flutter_map-6
 - Merge pull request #184 from shrijanRegmi/master
 
 ## [1.2.0] - 07/09/2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.3.0] - 10/11/2023
+
+- Merge pull request #184 from shrijanRegmi/master
+
 ## [1.2.0] - 07/09/2023
 
 - Merge pull request #175 from enricostrijks/master

--- a/example/lib/clustering_many_markers_page.dart
+++ b/example/lib/clustering_many_markers_page.dart
@@ -45,7 +45,7 @@ class _ClusteringManyMarkersPageState extends State<ClusteringManyMarkersPage> {
             height: 30,
             width: 30,
             point: latLng,
-            builder: (ctx) => const Icon(Icons.pin_drop),
+            child: const Icon(Icons.pin_drop),
           ),
         );
       }
@@ -61,9 +61,9 @@ class _ClusteringManyMarkersPageState extends State<ClusteringManyMarkersPage> {
       drawer: buildDrawer(context, ClusteringManyMarkersPage.route),
       body: FlutterMap(
         options: MapOptions(
-          center: LatLng((maxLatLng.latitude + minLatLng.latitude) / 2,
+          initialCenter: LatLng((maxLatLng.latitude + minLatLng.latitude) / 2,
               (maxLatLng.longitude + minLatLng.longitude) / 2),
-          zoom: 6,
+          initialZoom: 6,
           maxZoom: 15,
         ),
         children: <Widget>[
@@ -75,7 +75,7 @@ class _ClusteringManyMarkersPageState extends State<ClusteringManyMarkersPage> {
             options: MarkerClusterLayerOptions(
               maxClusterRadius: 45,
               size: const Size(40, 40),
-              anchorPos: AnchorPos.align(AnchorAlign.center),
+              alignment: Alignment.center,
               fitBoundsOptions: const FitBoundsOptions(
                 padding: EdgeInsets.all(50),
                 maxZoom: 15,

--- a/example/lib/clustering_page.dart
+++ b/example/lib/clustering_page.dart
@@ -28,130 +28,130 @@ class _ClusteringPageState extends State<ClusteringPage> {
     pointIndex = 0;
     markers = [
       Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+        alignment: Alignment.center,
         height: 30,
         width: 30,
         point: points[pointIndex],
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        child: const Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(53.3498, -6.2603),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(53.3488, -6.2613),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(53.3488, -6.2613),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(48.8566, 2.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
-      Marker(
-        anchorPos: AnchorPos.align(AnchorAlign.center),
+      const Marker(
+        alignment: Alignment.center,
         height: 30,
         width: 30,
-        point: const LatLng(49.8566, 3.3522),
-        builder: (ctx) => const Icon(Icons.pin_drop),
+        point: LatLng(49.8566, 3.3522),
+        child: Icon(Icons.pin_drop),
       ),
     ];
 
@@ -174,10 +174,10 @@ class _ClusteringPageState extends State<ClusteringPage> {
           setState(() {
             markers[0] = Marker(
               point: points[pointIndex],
-              anchorPos: AnchorPos.align(AnchorAlign.center),
+              alignment: Alignment.center,
               height: 30,
               width: 30,
-              builder: (ctx) => const Icon(Icons.pin_drop),
+              child: const Icon(Icons.pin_drop),
             );
             markers = List.from(markers);
           });
@@ -207,7 +207,7 @@ class _ClusteringPageState extends State<ClusteringPage> {
                 maxClusterRadius: 120,
                 rotate: true,
                 size: const Size(40, 40),
-                anchorPos: AnchorPos.align(AnchorAlign.center),
+                alignment: Alignment.center,
                 fitBoundsOptions: const FitBoundsOptions(
                   padding: EdgeInsets.all(50),
                   maxZoom: 15,
@@ -227,7 +227,7 @@ class _ClusteringPageState extends State<ClusteringPage> {
                           child: GestureDetector(
                             onTap: () => debugPrint('Popup tap!'),
                             child: Text(
-                              'Container popup for marker at ${marker.point}',
+                              'Container popup for marker',
                             ),
                           ),
                         )),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^5.0.0
+  flutter_map: ^6.0.0
   flutter_map_marker_cluster:
     path: ../
   cupertino_icons: ^1.0.5

--- a/lib/src/cluster_manager.dart
+++ b/lib/src/cluster_manager.dart
@@ -1,6 +1,5 @@
-import 'dart:ui';
-
-import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/src/core/distance_grid.dart';
 import 'package:flutter_map_marker_cluster/src/map_calculator.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_cluster_node.dart';
@@ -9,7 +8,7 @@ import 'package:flutter_map_marker_cluster/src/node/marker_or_cluster_node.dart'
 
 class ClusterManager {
   final MapCalculator mapCalculator;
-  final AnchorPos? anchorPos;
+  final Alignment? alignment;
   final Size predefinedSize;
   final Size Function(List<Marker>)? computeSize;
 
@@ -21,7 +20,7 @@ class ClusterManager {
 
   ClusterManager._({
     required this.mapCalculator,
-    required this.anchorPos,
+    required this.alignment,
     required this.predefinedSize,
     required this.computeSize,
     required Map<int, DistanceGrid<MarkerClusterNode>> gridClusters,
@@ -33,7 +32,7 @@ class ClusterManager {
 
   factory ClusterManager.initialize({
     required MapCalculator mapCalculator,
-    required AnchorPos? anchorPos,
+    required Alignment? alignment,
     required Size predefinedSize,
     required Size Function(List<Marker>)? computeSize,
     required int minZoom,
@@ -49,14 +48,14 @@ class ClusterManager {
     }
 
     final topClusterLevel = MarkerClusterNode(
-      anchorPos: anchorPos,
+      alignment: alignment,
       zoom: minZoom - 1,
       predefinedSize: predefinedSize,
       computeSize: computeSize,
     );
 
     return ClusterManager._(
-      anchorPos: anchorPos,
+      alignment: alignment,
       mapCalculator: mapCalculator,
       predefinedSize: predefinedSize,
       computeSize: computeSize,
@@ -91,7 +90,7 @@ class ClusterManager {
 
           final newCluster = MarkerClusterNode(
             zoom: zoom,
-            anchorPos: anchorPos,
+            alignment: alignment,
             predefinedSize: predefinedSize,
             computeSize: computeSize,
           )
@@ -111,7 +110,7 @@ class ClusterManager {
           for (var z = zoom - 1; z > parent.zoom; z--) {
             final newParent = MarkerClusterNode(
               zoom: z,
-              anchorPos: anchorPos,
+              alignment: alignment,
               predefinedSize: predefinedSize,
               computeSize: computeSize,
             );

--- a/lib/src/core/util.dart
+++ b/lib/src/core/util.dart
@@ -1,10 +1,12 @@
 import 'dart:math';
 
-import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter/material.dart';
 
-Point<double> removeAnchor(
-    Point pos, double width, double height, Anchor anchor) {
-  final x = (pos.x - (width - anchor.left)).toDouble();
-  final y = (pos.y - (height - anchor.top)).toDouble();
+Point<double> removeAlignment(
+    Point pos, double width, double height, Alignment alignment) {
+  final left = 0.5 * width * (alignment.x + 1);
+  final top = 0.5 * height * (alignment.y + 1);
+  final x = pos.x - (width - left);
+  final y = pos.y - (height - top);
   return Point(x, y);
 }

--- a/lib/src/map_calculator.dart
+++ b/lib/src/map_calculator.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 class MapCalculator {

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_map_marker_cluster/src/cluster_manager.dart';
 import 'package:flutter_map_marker_cluster/src/cluster_widget.dart';
@@ -125,7 +125,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
 
   void _initializeClusterManager() {
     _clusterManager = ClusterManager.initialize(
-      anchorPos: widget.options.anchorPos,
+      alignment: widget.options.alignment,
       mapCalculator: _mapCalculator,
       predefinedSize: widget.options.size,
       computeSize: widget.options.computeSize,
@@ -170,9 +170,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           ? null
           : Rotate(
               angle: -widget.mapCamera.rotationRad,
-              origin: marker.rotateOrigin ?? widget.options.rotateOrigin,
-              alignment:
-                  marker.rotateAlignment ?? widget.options.rotateAlignment,
+              origin: widget.options.rotateOrigin,
+              alignment: widget.options.rotateAlignment,
             ),
       key: marker.key ?? ObjectKey(marker.marker),
       child: MarkerWidget(

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map/plugin_api.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_map_marker_popup/extension_api.dart';
 
@@ -127,7 +126,7 @@ class MarkerClusterLayerOptions {
   final Size Function(List<Marker>)? computeSize;
 
   /// Cluster anchor
-  final AnchorPos? anchorPos;
+  final Alignment? alignment;
 
   /// A cluster will cover at most this many pixels from its center
   final int maxClusterRadius;
@@ -195,7 +194,7 @@ class MarkerClusterLayerOptions {
     this.markers = const [],
     this.size = const Size(30, 30),
     this.computeSize,
-    this.anchorPos,
+    this.alignment,
     this.maxClusterRadius = 80,
     this.disableClusteringAtZoom = 20,
     this.animationsOptions = const AnimationsOptions(),

--- a/lib/src/marker_cluster_layer_widget.dart
+++ b/lib/src/marker_cluster_layer_widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map/flutter_map.dart';
 
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 

--- a/lib/src/marker_widget.dart
+++ b/lib/src/marker_widget.dart
@@ -16,7 +16,6 @@ class MarkerWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final m = marker.builder(context);
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: onTap,
@@ -24,9 +23,9 @@ class MarkerWidget extends StatelessWidget {
           ? MouseRegion(
               onEnter: (_) => onHover!(true),
               onExit: (_) => onHover!(false),
-              child: m,
+              child: marker.child,
             )
-          : m,
+          : marker.child,
     );
   }
 }

--- a/lib/src/node/marker_cluster_node.dart
+++ b/lib/src/node/marker_cluster_node.dart
@@ -1,8 +1,7 @@
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_node.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_or_cluster_node.dart';
 import 'package:latlong2/latlong.dart';
@@ -51,7 +50,7 @@ class _Derived {
 
 class MarkerClusterNode extends MarkerOrClusterNode {
   final int zoom;
-  final AnchorPos? anchorPos;
+  final Alignment? alignment;
   final Size predefinedSize;
   final Size Function(List<Marker>)? computeSize;
   final children = <MarkerOrClusterNode>[];
@@ -60,7 +59,7 @@ class MarkerClusterNode extends MarkerOrClusterNode {
 
   MarkerClusterNode({
     required this.zoom,
-    required this.anchorPos,
+    required this.alignment,
     required this.predefinedSize,
     this.computeSize,
   }) : super(parent: null) {
@@ -130,20 +129,14 @@ class MarkerClusterNode extends MarkerOrClusterNode {
   Bounds<double> pixelBounds(MapCamera map) {
     final width = size().width;
     final height = size().height;
-    final anchor = Anchor.fromPos(
-      anchorPos ?? AnchorPos.defaultAnchorPos,
-      width,
-      height,
-    );
 
-    final rightPortion = width - anchor.left;
-    final leftPortion = anchor.left;
-    final bottomPortion = height - anchor.top;
-    final topPortion = anchor.top;
+    final left = 0.5 * width * ((alignment ?? Alignment.center).x + 1);
+    final top = 0.5 * height * ((alignment ?? Alignment.center).y + 1);
+    final right = width - left;
+    final bottom = height - top;
 
-    final ne = map.project(bounds.northEast) + Point(rightPortion, -topPortion);
-    final sw =
-        map.project(bounds.southWest) + Point(-leftPortion, bottomPortion);
+    final ne = map.project(bounds.northEast) + Point(right, -top);
+    final sw = map.project(bounds.southWest) + Point(-left, bottom);
 
     return Bounds(ne, sw);
   }

--- a/lib/src/node/marker_node.dart
+++ b/lib/src/node/marker_node.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_or_cluster_node.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -14,7 +14,7 @@ class MarkerNode extends MarkerOrClusterNode implements Marker {
   Key? get key => marker.key;
 
   @override
-  WidgetBuilder get builder => marker.builder;
+  Widget get child => marker.child;
 
   @override
   double get height => marker.height;
@@ -29,33 +29,20 @@ class MarkerNode extends MarkerOrClusterNode implements Marker {
   bool? get rotate => marker.rotate;
 
   @override
-  AlignmentGeometry? get rotateAlignment => marker.rotateAlignment;
-
-  @override
-  Offset? get rotateOrigin => marker.rotateOrigin;
-
-  @override
-  Anchor? get anchor => marker.anchor;
+  Alignment? get alignment => marker.alignment;
 
   @override
   Bounds<double> pixelBounds(MapCamera map) {
     final pixelPoint = map.project(point);
 
-    final ankr = anchor ??
-        Anchor.fromPos(
-          AnchorPos.defaultAnchorPos,
-          width,
-          height,
-        );
+    final left = 0.5 * width * ((alignment ?? Alignment.center).x + 1);
+    final top = 0.5 * height * ((alignment ?? Alignment.center).y + 1);
+    final right = width - left;
+    final bottom = height - top;
 
-    final rightPortion = width - ankr.left;
-    final leftPortion = ankr.left;
-    final bottomPortion = height - ankr.top;
-    final topPortion = ankr.top;
-
-    final ne = Point(pixelPoint.x - rightPortion, pixelPoint.y + topPortion);
-    final sw = Point(pixelPoint.x + leftPortion, pixelPoint.y - bottomPortion);
-
-    return Bounds(ne, sw);
+    return Bounds(
+      Point(pixelPoint.x + left, pixelPoint.y - bottom),
+      Point(pixelPoint.x - right, pixelPoint.y + top),
+    );
   }
 }

--- a/lib/src/node/marker_or_cluster_node.dart
+++ b/lib/src/node/marker_or_cluster_node.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_cluster_node.dart';
 
 /// Just a base class which MarkerNode and MarkerClusterNode both extend which

--- a/lib/src/translate.dart
+++ b/lib/src/translate.dart
@@ -1,8 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/animation.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter_map/plugin_api.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_map_marker_cluster/src/core/util.dart' as util;
 import 'package:flutter_map_marker_cluster/src/map_calculator.dart';
 import 'package:flutter_map_marker_cluster/src/node/marker_cluster_node.dart';
@@ -40,13 +38,8 @@ abstract class Translate {
     LatLng? customPoint,
   }) {
     final pos = mapCalculator.getPixelFromPoint(customPoint ?? marker.point);
-    final anchor = marker.anchor ??
-        Anchor.fromPos(
-          AnchorPos.defaultAnchorPos,
-          marker.width,
-          marker.height,
-        );
-    return util.removeAnchor(pos, marker.width, marker.height, anchor);
+    return util.removeAlignment(
+        pos, marker.width, marker.height, marker.alignment ?? Alignment.center);
   }
 
   static Point<double> _getClusterPixel(
@@ -58,17 +51,12 @@ abstract class Translate {
         .getPixelFromPoint(customPoint ?? clusterNode.bounds.center);
 
     final calculatedSize = clusterNode.size();
-    final anchor = Anchor.fromPos(
-      clusterNode.anchorPos ?? AnchorPos.defaultAnchorPos,
-      calculatedSize.width,
-      calculatedSize.height,
-    );
 
-    return util.removeAnchor(
+    return util.removeAlignment(
       pos,
       calculatedSize.width,
       calculatedSize.height,
-      anchor,
+      clusterNode.alignment ?? Alignment.center,
     );
   }
 }
@@ -134,16 +122,11 @@ class AnimatedTranslate extends Translate {
           marker,
           customPoint: cluster.bounds.center,
         ),
-        newPosition = util.removeAnchor(
+        newPosition = util.removeAlignment(
           point,
           marker.width,
           marker.height,
-          marker.anchor ??
-              Anchor.fromPos(
-                AnchorPos.defaultAnchorPos,
-                marker.width,
-                marker.height,
-              ),
+          marker.alignment ?? Alignment.center,
         ) {
     _tween = Tween<Point<double>>(
       begin: Point(position.x, position.y),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_map_marker_cluster
 description: A Dart implementation of Leaflet.makercluster for Flutter apps.
   Provides beautiful animated marker clustering functionality for flutter_map.
-version: 1.2.0
+version: 1.3.0
 
 homepage: https://github.com/lpongetti/flutter_map_marker_cluster
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^6.0.0-dev.3
+  flutter_map: ^6.0.0
   flutter_map_marker_popup: ^5.2.0
   latlong2: ^0.9.0
 

--- a/test/distance_grid_test.dart
+++ b/test/distance_grid_test.dart
@@ -9,9 +9,9 @@ import 'package:latlong2/latlong.dart';
 void main() {
   test('addObject', () {
     final grid = DistanceGrid<Marker>(100),
-        obj = Marker(
-          point: const LatLng(1, 2),
-          builder: (ctx) => const FlutterLogo(),
+        obj = const Marker(
+          point: LatLng(1, 2),
+          child: FlutterLogo(),
         );
 
     grid.addObject(obj, const Point(0, 0));
@@ -20,9 +20,9 @@ void main() {
 
   test('eachObject', () {
     final grid = DistanceGrid<Marker>(100),
-        obj = Marker(
-          point: const LatLng(1, 2),
-          builder: (ctx) => const FlutterLogo(),
+        obj = const Marker(
+          point: LatLng(1, 2),
+          child: FlutterLogo(),
         );
 
     grid.addObject(obj, const Point(0, 0));
@@ -34,9 +34,9 @@ void main() {
 
   test('getNearObject', () {
     final grid = DistanceGrid<Marker>(100),
-        obj = Marker(
-          point: const LatLng(1, 2),
-          builder: (ctx) => const FlutterLogo(),
+        obj = const Marker(
+          point: LatLng(1, 2),
+          child: FlutterLogo(),
         );
 
     grid.addObject(obj, const Point(0, 0));
@@ -47,9 +47,9 @@ void main() {
 
   test('getNearObject double', () {
     final grid = DistanceGrid<Marker>(100),
-        obj = Marker(
-          point: const LatLng(1, 2),
-          builder: (ctx) => const FlutterLogo(),
+        obj = const Marker(
+          point: LatLng(1, 2),
+          child: FlutterLogo(),
         );
 
     grid.addObject(obj, const Point(0, 0));
@@ -61,13 +61,13 @@ void main() {
 
   test('getNearObject with cellSize 0', () {
     final grid = DistanceGrid<Marker>(0),
-        obj1 = Marker(
-          point: const LatLng(1, 2),
-          builder: (ctx) => const FlutterLogo(),
+        obj1 = const Marker(
+          point: LatLng(1, 2),
+          child: FlutterLogo(),
         ),
-        obj2 = Marker(
-          point: const LatLng(2, 3),
-          builder: (ctx) => const FlutterLogo(),
+        obj2 = const Marker(
+          point: LatLng(2, 3),
+          child: FlutterLogo(),
         );
 
     grid.addObject(obj1, const Point(50, 50));
@@ -79,13 +79,13 @@ void main() {
 
   test('getNearObject with cellSize 0 double', () {
     final grid = DistanceGrid<Marker>(0),
-        obj1 = Marker(
-          point: const LatLng(1, 2),
-          builder: (ctx) => const FlutterLogo(),
+        obj1 = const Marker(
+          point: LatLng(1, 2),
+          child: FlutterLogo(),
         ),
-        obj2 = Marker(
-          point: const LatLng(2, 3),
-          builder: (ctx) => const FlutterLogo(),
+        obj2 = const Marker(
+          point: LatLng(2, 3),
+          child: FlutterLogo(),
         );
 
     grid.addObject(obj1, const Point(50.0, 50.0));


### PR DESCRIPTION
Hey folks! I tried switching to flutter_map v6.0.0, but flutter_map_popup for this version isn't out yet. Can someone take a look and help improve this PR?
There are also some deprecated classes that we still use like FitBoundsOptions or mapController.centerZoomFitBounds.
Thanks a bunch!