### PR TITLE
Don't fitBounds before spiderfy if bounds are already fit

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -677,6 +677,17 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       final zoomTween =
           Tween<double>(begin: widget.mapCamera.zoom, end: dest.zoom);
 
+      final isAlreadyFit = latTween.begin == latTween.end &&
+          lonTween.begin == lonTween.end &&
+          zoomTween.begin == zoomTween.end;
+
+      if (isAlreadyFit) {
+        if (cannotDivide && widget.options.spiderfyCluster) {
+          _spiderfy(cluster);
+        }
+        return;
+      }
+
       final animation = CurvedAnimation(
           parent: _fitBoundController,
           curve: widget.options.animationsOptions.fitBoundCurves);


### PR DESCRIPTION
Currently if you tap on a cluster and your map bounds are already 'fit' then you will wait the full length of the animation duration before the spiderfy begins. This PR makes it such that if the bounds are already fit, (aka there won't be any map movement on tap), then skip the animation and immediately spiderfy, making the spiderfy feel a lot snappier.