### PR TITLE
PopupLayer rotation fix

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -33,8 +33,7 @@ class MarkerClusterLayer extends StatefulWidget {
   State<MarkerClusterLayer> createState() => _MarkerClusterLayerState();
 }
 
-class _MarkerClusterLayerState extends State<MarkerClusterLayer>
-    with TickerProviderStateMixin {
+class _MarkerClusterLayerState extends State<MarkerClusterLayer> with TickerProviderStateMixin {
   late MapCalculator _mapCalculator;
   late ClusterManager _clusterManager;
   late int _maxZoom;
@@ -53,21 +52,14 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
   _MarkerClusterLayerState();
 
   bool _isSpiderfyCluster(MarkerClusterNode cluster) {
-    return spiderfyCluster != null &&
-        spiderfyCluster!.bounds.center == cluster.bounds.center;
+    return spiderfyCluster != null && spiderfyCluster!.bounds.center == cluster.bounds.center;
   }
 
-  bool get _animating =>
-      _zoomController.isAnimating ||
-      _fitBoundController.isAnimating ||
-      _centerMarkerController.isAnimating ||
-      _spiderfyController.isAnimating;
+  bool get _animating => _zoomController.isAnimating || _fitBoundController.isAnimating || _centerMarkerController.isAnimating || _spiderfyController.isAnimating;
 
-  bool get _zoomingIn =>
-      _zoomController.isAnimating && _currentZoom > _previousZoom;
+  bool get _zoomingIn => _zoomController.isAnimating && _currentZoom > _previousZoom;
 
-  bool get _zoomingOut =>
-      _zoomController.isAnimating && _currentZoom < _previousZoom;
+  bool get _zoomingOut => _zoomController.isAnimating && _currentZoom < _previousZoom;
 
   @override
   void initState() {
@@ -157,10 +149,25 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
 
   @override
   Widget build(BuildContext context) {
-    return MobileLayerTransformer(
-      child: Stack(
-        children: _buildLayers(),
-      ),
+    final popupOptions = widget.options.popupOptions;
+    return Stack(
+      children: [
+        // Keep the layers in a MobileTransformStack
+        MobileLayerTransformer(
+          child: Stack(
+            children: _buildMobileTransformStack(),
+          ),
+        ),
+        // Move the PopupLayer outside the MobileLayerTransformer since it has its own
+        if (popupOptions != null)
+          PopupLayer(
+            popupDisplayOptions: PopupDisplayOptions(
+              builder: popupOptions.popupBuilder,
+              animation: popupOptions.popupAnimation,
+              snap: popupOptions.popupSnap,
+            ),
+          )
+      ],
     );
   }
 
@@ -194,18 +201,12 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
   /// Function that is called when the marker is hover (if popup building on hover is selected).
   /// if enter == true then it's onHoverEnter, if enter == false it's onHoverExit
   void _onMarkerHover(MarkerNode marker, bool enter) {
-    if (_zoomController.isAnimating ||
-        _centerMarkerController.isAnimating ||
-        _fitBoundController.isAnimating) return;
+    if (_zoomController.isAnimating || _centerMarkerController.isAnimating || _fitBoundController.isAnimating) return;
 
     if (widget.options.popupOptions != null) {
       final popupOptions = widget.options.popupOptions!;
       enter
-          ? Future.delayed(
-              Duration(
-                  milliseconds: popupOptions.timeToShowPopupOnHover >= 0
-                      ? popupOptions.timeToShowPopupOnHover
-                      : 0), () {
+          ? Future.delayed(Duration(milliseconds: popupOptions.timeToShowPopupOnHover >= 0 ? popupOptions.timeToShowPopupOnHover : 0), () {
               popupOptions.markerTapBehavior.apply(
                 PopupSpec.wrap(marker.marker),
                 PopupState.maybeOf(context, listen: false)!,
@@ -216,9 +217,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     }
 
     if (widget.options.onMarkerTap != null) {
-      enter
-          ? widget.options.onMarkerHoverEnter?.call(marker.marker)
-          : widget.options.onMarkerHoverExit?.call(marker.marker);
+      enter ? widget.options.onMarkerHoverEnter?.call(marker.marker) : widget.options.onMarkerHoverExit?.call(marker.marker);
     }
   }
 
@@ -232,18 +231,14 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
   Future<void> _unspiderfy() async {
     switch (_spiderfyController.status) {
       case AnimationStatus.completed:
-        final markersGettingClustered = spiderfyCluster?.markers
-            .map((markerNode) => markerNode.marker)
-            .toList();
+        final markersGettingClustered = spiderfyCluster?.markers.map((markerNode) => markerNode.marker).toList();
 
-        if (widget.options.popupOptions != null &&
-            markersGettingClustered != null) {
+        if (widget.options.popupOptions != null && markersGettingClustered != null) {
           widget.options.popupOptions!.popupController.hidePopupsOnlyFor(
             markersGettingClustered,
           );
         }
-        if (widget.options.onMarkersClustered != null &&
-            markersGettingClustered != null) {
+        if (widget.options.onMarkersClustered != null && markersGettingClustered != null) {
           widget.options.onMarkersClustered!(markersGettingClustered);
         }
 
@@ -254,13 +249,10 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
             );
         break;
       case AnimationStatus.forward:
-        final markersGettingClustered = spiderfyCluster?.markers
-            .map((markerNode) => markerNode.marker)
-            .toList();
+        final markersGettingClustered = spiderfyCluster?.markers.map((markerNode) => markerNode.marker).toList();
 
         if (markersGettingClustered != null) {
-          widget.options.popupOptions?.popupController
-              .hidePopupsOnlyFor(markersGettingClustered);
+          widget.options.popupOptions?.popupController.hidePopupsOnlyFor(markersGettingClustered);
           widget.options.onMarkersClustered?.call(markersGettingClustered);
         }
 
@@ -315,8 +307,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
                 angle: -widget.mapCamera.rotationRad,
                 alignment: widget.options.alignment,
               ),
-        fade:
-            Fade.fadeOut(curve: widget.options.animationsOptions.fadeOutCurve),
+        fade: Fade.fadeOut(curve: widget.options.animationsOptions.fadeOutCurve),
         child: ClusterWidget(
           cluster: markerNode.parent!,
           builder: widget.options.builder,
@@ -326,12 +317,10 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     );
   }
 
-  void _addMarkerClusterLayer(MarkerClusterNode clusterNode,
-      List<Widget> layers, List<Widget> spiderfyLayers) {
+  void _addMarkerClusterLayer(MarkerClusterNode clusterNode, List<Widget> layers, List<Widget> spiderfyLayers) {
     if (_zoomingOut && clusterNode.children.length > 1) {
       _addClusterClosingLayer(clusterNode, layers);
-    } else if (_zoomingIn &&
-        clusterNode.parent!.bounds.center != clusterNode.bounds.center) {
+    } else if (_zoomingIn && clusterNode.parent!.bounds.center != clusterNode.bounds.center) {
       _addClusterOpeningLayer(clusterNode, layers);
     } else if (_isSpiderfyCluster(clusterNode)) {
       spiderfyLayers.addAll(_buildSpiderfyCluster(clusterNode, _currentZoom));
@@ -357,8 +346,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     }
   }
 
-  void _addClusterClosingLayer(
-      MarkerClusterNode clusterNode, List<Widget> layers) {
+  void _addClusterClosingLayer(MarkerClusterNode clusterNode, List<Widget> layers) {
     // cluster
     layers.add(
       MapWidget(
@@ -390,8 +378,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           _buildMarker(
             marker: child,
             controller: _zoomController,
-            fade: Fade.fadeOut(
-                curve: widget.options.animationsOptions.fadeOutCurve),
+            fade: Fade.fadeOut(curve: widget.options.animationsOptions.fadeOutCurve),
             translate: AnimatedTranslate.fromMyPosToNewPos(
               mapCalculator: _mapCalculator,
               from: child,
@@ -418,8 +405,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
                     angle: -widget.mapCamera.rotationRad,
                     alignment: widget.options.alignment,
                   ),
-            fade: Fade.fadeOut(
-                curve: widget.options.animationsOptions.fadeOutCurve),
+            fade: Fade.fadeOut(curve: widget.options.animationsOptions.fadeOutCurve),
             child: ClusterWidget(
               cluster: child,
               builder: widget.options.builder,
@@ -436,8 +422,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     widget.options.onMarkersClustered?.call(markersGettingClustered);
   }
 
-  void _addClusterOpeningLayer(
-      MarkerClusterNode clusterNode, List<Widget> layers) {
+  void _addClusterOpeningLayer(MarkerClusterNode clusterNode, List<Widget> layers) {
     // cluster
     layers.add(MapWidget(
       size: clusterNode.size(),
@@ -497,8 +482,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
                 angle: -widget.mapCamera.rotationRad,
                 alignment: widget.options.alignment,
               ),
-        fade: Fade.almostFadeOut(
-            curve: widget.options.animationsOptions.fadeOutCurve),
+        fade: Fade.almostFadeOut(curve: widget.options.animationsOptions.fadeOutCurve),
         child: ClusterWidget(
           cluster: cluster,
           builder: widget.options.builder,
@@ -518,8 +502,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         _buildMarker(
           marker: marker,
           controller: _spiderfyController,
-          fade:
-              Fade.fadeIn(curve: widget.options.animationsOptions.fadeInCurve),
+          fade: Fade.fadeIn(curve: widget.options.animationsOptions.fadeInCurve),
           translate: AnimatedTranslate.spiderfy(
             mapCalculator: _mapCalculator,
             cluster: cluster,
@@ -533,7 +516,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     return results;
   }
 
-  List<Widget> _buildLayers() {
+  List<Widget> _buildMobileTransformStack() {
     if (widget.mapCamera.zoom != _previousZoomDouble) {
       _previousZoomDouble = widget.mapCamera.zoom;
       _unspiderfy();
@@ -574,9 +557,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       0.5,
     );
 
-    _clusterManager.recursivelyFromTopClusterLevel(
-        _currentZoom, widget.options.disableClusteringAtZoom, recursionBounds,
-        (MarkerOrClusterNode layer) {
+    _clusterManager.recursivelyFromTopClusterLevel(_currentZoom, widget.options.disableClusteringAtZoom, recursionBounds, (MarkerOrClusterNode layer) {
       // This is the performance critical hot path recursed on every map event!
 
       // Cull markers/clusters that are not on screen.
@@ -597,17 +578,6 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
 
     // ensures the spiderfy layers markers are on top of other markers and clusters
     layers.addAll(spiderfyLayers);
-
-    final popupOptions = widget.options.popupOptions;
-    if (popupOptions != null) {
-      layers.add(PopupLayer(
-        popupDisplayOptions: PopupDisplayOptions(
-            builder: popupOptions.popupBuilder,
-            animation: popupOptions.popupAnimation,
-            snap: popupOptions.popupSnap),
-      ));
-    }
-
     return layers;
   }
 
@@ -646,19 +616,12 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       ).fit(widget.mapCamera);
 
       // check if children can un-cluster
-      final cannotDivide = cluster.markers.every((marker) =>
-              marker.parent!.zoom == _maxZoom &&
-              marker.parent == cluster.markers.first.parent) ||
+      final cannotDivide = cluster.markers.every((marker) => marker.parent!.zoom == _maxZoom && marker.parent == cluster.markers.first.parent) ||
           (dest.zoom == _currentZoom && _currentZoom == opt.maxZoom);
 
       if (cannotDivide) {
         //dest = CenterZoom(center: dest.center, zoom: _currentZoom.toDouble());
-        dest = MapCamera(
-            crs: dest.crs,
-            center: dest.center,
-            zoom: _currentZoom.toDouble(),
-            rotation: dest.rotation,
-            nonRotatedSize: dest.nonRotatedSize);
+        dest = MapCamera(crs: dest.crs, center: dest.center, zoom: _currentZoom.toDouble(), rotation: dest.rotation, nonRotatedSize: dest.nonRotatedSize);
 
         if (spiderfyCluster != null) {
           if (spiderfyCluster == cluster) {
@@ -674,16 +637,11 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         _showPolygon(cluster.markers.map((m) => m.point).toList());
       }
 
-      final latTween =
-          Tween<double>(begin: center.latitude, end: dest.center.latitude);
-      final lonTween =
-          Tween<double>(begin: center.longitude, end: dest.center.longitude);
-      final zoomTween =
-          Tween<double>(begin: widget.mapCamera.zoom, end: dest.zoom);
+      final latTween = Tween<double>(begin: center.latitude, end: dest.center.latitude);
+      final lonTween = Tween<double>(begin: center.longitude, end: dest.center.longitude);
+      final zoomTween = Tween<double>(begin: widget.mapCamera.zoom, end: dest.zoom);
 
-      final isAlreadyFit = latTween.begin == latTween.end &&
-          lonTween.begin == lonTween.end &&
-          zoomTween.begin == zoomTween.end;
+      final isAlreadyFit = latTween.begin == latTween.end && lonTween.begin == lonTween.end && zoomTween.begin == zoomTween.end;
 
       if (isAlreadyFit) {
         if (cannotDivide && widget.options.spiderfyCluster) {
@@ -692,12 +650,9 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         return;
       }
 
-      final animation = CurvedAnimation(
-          parent: _fitBoundController,
-          curve: widget.options.animationsOptions.fitBoundCurves);
+      final animation = CurvedAnimation(parent: _fitBoundController, curve: widget.options.animationsOptions.fitBoundCurves);
 
-      final listener = _centerMarkerListener(animation, latTween, lonTween,
-          zoomTween: zoomTween);
+      final listener = _centerMarkerListener(animation, latTween, lonTween, zoomTween: zoomTween);
 
       _fitBoundController.addListener(listener);
 
@@ -731,10 +686,8 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       if (!widget.options.centerMarkerOnClick) return;
 
       final center = widget.mapCamera.center;
-      final latTween =
-          Tween<double>(begin: center.latitude, end: marker.point.latitude);
-      final lonTween =
-          Tween<double>(begin: center.longitude, end: marker.point.longitude);
+      final latTween = Tween<double>(begin: center.latitude, end: marker.point.latitude);
+      final lonTween = Tween<double>(begin: center.longitude, end: marker.point.longitude);
 
       final Animation<double> animation = CurvedAnimation(
         parent: _centerMarkerController,
@@ -815,10 +768,8 @@ LatLngBounds _extendBounds(LatLngBounds bounds, double stickonFactor) {
   // Clamp rather than wrap around. This function is used in the context of
   // drawing things onto a map. Since the map renderer does't wrap maps itself,
   // we also shouldn't wrap around the bounding boxes.
-  final point1 = LatLng((bounds.south - height).clamp(-90, 90),
-      (bounds.west - width).clamp(-180, 180));
-  final point2 = LatLng((bounds.north + height).clamp(-90, 90),
-      (bounds.east + width).clamp(-180, 180));
+  final point1 = LatLng((bounds.south - height).clamp(-90, 90), (bounds.west - width).clamp(-180, 180));
+  final point2 = LatLng((bounds.north + height).clamp(-90, 90), (bounds.east + width).clamp(-180, 180));
 
   return LatLngBounds(point1, point2);
 }


### PR DESCRIPTION
The marker popups didn't rotate correctly as the `PopupLayer` was wrapped into a `MobileLayerTransformer` while it has its own internally.
Moved the `PopupLayer` outside the `MobileLayerTransformer`: https://github.com/tratteo/flutter_map_marker_cluster/blob/d0a996c0d48ff5eeac54273667ac2023a2fc4a2a/lib/src/marker_cluster_layer.dart#L153
