### PR TITLE
Remove subdomains from OSM urlTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ dependencies:
         ),
         children: <Widget>[
           TileLayer(
-            urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            subdomains: const ['a', 'b', 'c'],
+            urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
           ),
           MarkerClusterLayerWidget(
             options: MarkerClusterLayerOptions(


### PR DESCRIPTION
Subdomains usage is deprecated: https://github.com/openstreetmap/operations/issues/737