### PR TITLE
Add markerChildBehavior option to MarkerWidget

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -199,6 +199,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       key: marker.key ?? ObjectKey(marker.marker),
       child: MarkerWidget(
         marker: marker,
+        markerChildBehavior: widget.options.markerChildBehavior,
         onTap: _onMarkerTap(marker),
         onHover: (bool value) => _onMarkerHover(marker, value),
         buildOnHover: widget.options.popupOptions?.buildPopupOnHover ?? false,

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -169,6 +169,14 @@ class MarkerClusterLayerOptions {
   /// Function to call when a cluster Marker is tapped
   final void Function(MarkerClusterNode)? onClusterTap;
 
+  
+  ///If set to [true] the marker will have only gesture behavior that is provided by the marker child.
+  ///Can be used in cases where the marker child is a widget that already has gesture behavior and [GestureDetector] from the [MarkerClusterLayer] is interfering with it.
+  ///If set to [true] [onMarkerTap] [onMarkerHoverEnter] [onMarkerHoverExit] [centerMarkerOnClick] will not work.
+  ///
+  ///Defaults to [false].
+  final bool markerChildBehavior;
+
   /// Popup's options that show when tapping markers or via the PopupController.
   final PopupOptions? popupOptions;
 
@@ -210,5 +218,6 @@ class MarkerClusterLayerOptions {
     this.onClusterTap,
     this.onMarkersClustered,
     this.popupOptions,
+    this.markerChildBehavior = false,
   });
 }

--- a/lib/src/marker_widget.dart
+++ b/lib/src/marker_widget.dart
@@ -6,26 +6,30 @@ class MarkerWidget extends StatelessWidget {
   final VoidCallback onTap;
   final Function(bool)? onHover;
   final bool buildOnHover;
+  final bool markerChildBehavior;
 
   MarkerWidget({
     required this.marker,
     required this.onTap,
+    required this.markerChildBehavior,
     this.onHover,
     this.buildOnHover = false,
   }) : super(key: marker.key ?? ObjectKey(marker.marker));
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: onTap,
-      child: buildOnHover && onHover != null
-          ? MouseRegion(
-              onEnter: (_) => onHover!(true),
-              onExit: (_) => onHover!(false),
-              child: marker.child,
-            )
-          : marker.child,
-    );
+    return markerChildBehavior
+        ? marker.child
+        : GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: onTap,
+            child: buildOnHover && onHover != null
+                ? MouseRegion(
+                    onEnter: (_) => onHover!(true),
+                    onExit: (_) => onHover!(false),
+                    child: marker.child,
+                  )
+                : marker.child,
+          );
   }
 }


### PR DESCRIPTION
Added simple way to opt out using GestureDetector for MarkerWidget  as it is interfering with gesture detector behavior provided by MarkerChild. 
This functionality  was needed as Marker I made have a custom GestureDtetector that reacts on events only within marker shape.