### PR TITLE
Add marker double tap

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -201,6 +201,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
         marker: marker,
         markerChildBehavior: widget.options.markerChildBehavior,
         onTap: _onMarkerTap(marker),
+        onDoubleTap: _onMarkerDoubleTap(marker),
         onHover: (bool value) => _onMarkerHover(marker, value),
         buildOnHover: widget.options.popupOptions?.buildPopupOnHover ?? false,
       ),
@@ -753,6 +754,14 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           ..removeListener(listener)
           ..reset();
       });
+    };
+  }
+
+  VoidCallback _onMarkerDoubleTap(MarkerNode marker) {
+    return () {
+      if (_animating) return;
+
+      widget.options.onMarkerTap?.call(marker.marker);
     };
   }
 

--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -761,7 +761,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     return () {
       if (_animating) return;
 
-      widget.options.onMarkerTap?.call(marker.marker);
+      widget.options.onMarkerDoubleTap?.call(marker.marker);
     };
   }
 

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -157,6 +157,9 @@ class MarkerClusterLayerOptions {
   /// Function to call when a Marker is tapped
   final void Function(Marker)? onMarkerTap;
 
+  /// Function to call when a Marker is double tapped
+  final void Function(Marker)? onMarkerDoubleTap;
+
   /// Function to call when a Marker starts to be hovered
   final void Function(Marker)? onMarkerHoverEnter;
 
@@ -212,6 +215,7 @@ class MarkerClusterLayerOptions {
     this.polygonOptions = const PolygonOptions(),
     this.showPolygon = true,
     this.onMarkerTap,
+    this.onMarkerDoubleTap,
     this.onMarkerHoverEnter,
     this.onMarkerHoverExit,
     this.onClusterTap,

--- a/lib/src/marker_widget.dart
+++ b/lib/src/marker_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter_map_marker_cluster/src/node/marker_node.dart';
 class MarkerWidget extends StatelessWidget {
   final MarkerNode marker;
   final VoidCallback onTap;
+  final VoidCallback onDoubleTap;
   final Function(bool)? onHover;
   final bool buildOnHover;
   final bool markerChildBehavior;
@@ -11,6 +12,7 @@ class MarkerWidget extends StatelessWidget {
   MarkerWidget({
     required this.marker,
     required this.onTap,
+    required this.onDoubleTap,
     required this.markerChildBehavior,
     this.onHover,
     this.buildOnHover = false,
@@ -23,6 +25,7 @@ class MarkerWidget extends StatelessWidget {
         : GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTap: onTap,
+            onDoubleTap: onDoubleTap,
             child: buildOnHover && onHover != null
                 ? MouseRegion(
                     onEnter: (_) => onHover!(true),


### PR DESCRIPTION
I'd like to introduce a zoom to marker feature when a marker is double tapped. Without adding a gesture detector over the top of the marker there isn't a way to do this.

This PR exposes the double tap method of the marker's GestureDetector for use.