### PR TITLE
Support for flutter_map prerelease version 7.0.0-dev.1

### DIFF
--- a/lib/src/map_calculator.dart
+++ b/lib/src/map_calculator.dart
@@ -9,10 +9,7 @@ class MapCalculator {
   MapCalculator(this.mapState);
 
   Point<double> getPixelFromPoint(LatLng point) {
-    return mapState
-        .project(point)
-        .subtract(mapState.pixelOrigin)
-        .toDoublePoint();
+    return mapState.project(point) - mapState.pixelOrigin.toDoublePoint();
   }
 
   Point<double> project(LatLng latLng, {double? zoom}) =>


### PR DESCRIPTION
Hi there!

I would like to use the newest prerelease of flutter_map and came across an issue with the Point class of dart:math because the subtract method is not supported anymore.

Looking forward for a new release 😊