### PR TITLE
Migration to flutter map v7

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -788,7 +788,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
             borderStrokeWidth: widget.options.polygonOptions.borderStrokeWidth,
             color: widget.options.polygonOptions.color,
             borderColor: widget.options.polygonOptions.borderColor,
-            isDotted: widget.options.polygonOptions.isDotted,
+            pattern: widget.options.polygonOptions.pattern,
           ),
         ]);
       });

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -9,13 +9,13 @@ class PolygonOptions {
   final Color color;
   final double borderStrokeWidth;
   final Color borderColor;
-  final bool isDotted;
+  final StrokePattern pattern;
 
   const PolygonOptions({
     this.color = const Color(0xFF00FF00),
     this.borderStrokeWidth = 0.0,
     this.borderColor = const Color(0xFFFFFF00),
-    this.isDotted = false,
+    this.pattern = const StrokePattern.solid(),
   });
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,10 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_map: ">=7.0.0 <8.0.0"
-  flutter_map_marker_popup:
-    git:
-      ref: master
-      url: https://github.com/pento/flutter_map_marker_popup/
+  flutter_map_marker_popup: ^7.0.0
   latlong2: ^0.9.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ">=6.0.0 <7.0.0"
-  flutter_map_marker_popup: ">=6.1.2 <7.0.0"
+  flutter_map: ">=7.0.0 <8.0.0"
+  flutter_map_marker_popup:
+    git:
+      ref: master
+      url: https://github.com/pento/flutter_map_marker_popup/
   latlong2: ^0.9.0
 
 dev_dependencies:


### PR DESCRIPTION
**This merge is blocked by the release of [this](https://github.com/rorystephenson/flutter_map_marker_popup/pull/78) flutter_map_marker_popup pr** 

- migrated PolygonOptions isDotted to pattern as the flutter_map Polygon now uses pattern instead of a bool flag for line styling
