### PR TITLE
fix: Fix onTap marker delay issue

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -757,7 +757,9 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
     };
   }
 
-  VoidCallback _onMarkerDoubleTap(MarkerNode marker) {
+  VoidCallback? _onMarkerDoubleTap(MarkerNode marker) {
+    if (widget.options.onMarkerDoubleTap == null) return null;
+
     return () {
       if (_animating) return;
 

--- a/lib/src/marker_widget.dart
+++ b/lib/src/marker_widget.dart
@@ -4,7 +4,7 @@ import 'package:flutter_map_marker_cluster/src/node/marker_node.dart';
 class MarkerWidget extends StatelessWidget {
   final MarkerNode marker;
   final VoidCallback onTap;
-  final VoidCallback onDoubleTap;
+  final VoidCallback? onDoubleTap;
   final Function(bool)? onHover;
   final bool buildOnHover;
   final bool markerChildBehavior;
@@ -12,7 +12,7 @@ class MarkerWidget extends StatelessWidget {
   MarkerWidget({
     required this.marker,
     required this.onTap,
-    required this.onDoubleTap,
+    this.onDoubleTap,
     required this.markerChildBehavior,
     this.onHover,
     this.buildOnHover = false,


### PR DESCRIPTION
An onDoubleTap feature was recently added to the marker widget. This causes a delay in the onTap action because the GestureDetector waits to see if the user will double tap. To fix this, set the default value of onDoubleTap to null and make it optional. This way, the onTap action will not be delayed if onDoubleTap is null.