### PR TITLE
Add spiderfy marker limit

### DIFF
--- a/lib/src/marker_cluster_layer.dart
+++ b/lib/src/marker_cluster_layer.dart
@@ -50,6 +50,13 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
 
   _MarkerClusterLayerState();
 
+  bool _shouldSpiderfy(MarkerClusterNode cluster) {
+    return widget.options.spiderfyCluster &&
+        (widget.options.disableSpiderfyAboveMarkerCount <= 0 ||
+            cluster.markers.length <=
+                widget.options.disableSpiderfyAboveMarkerCount);
+  }
+
   bool _isSpiderfyCluster(MarkerClusterNode cluster) {
     return spiderfyCluster != null &&
         spiderfyCluster!.bounds.center == cluster.bounds.center;
@@ -623,7 +630,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
       widget.options.onClusterTap?.call(cluster);
 
       if (!widget.options.zoomToBoundsOnClick) {
-        if (widget.options.spiderfyCluster) {
+        if (_shouldSpiderfy(cluster)) {
           if (spiderfyCluster != null) {
             if (spiderfyCluster == cluster) {
               _unspiderfy();
@@ -691,7 +698,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           zoomTween.begin == zoomTween.end;
 
       if (isAlreadyFit) {
-        if (cannotDivide && widget.options.spiderfyCluster) {
+        if (cannotDivide && _shouldSpiderfy(cluster)) {
           _spiderfy(cluster);
         }
         return;
@@ -711,7 +718,7 @@ class _MarkerClusterLayerState extends State<MarkerClusterLayer>
           ..removeListener(listener)
           ..reset();
 
-        if (cannotDivide && widget.options.spiderfyCluster) {
+        if (cannotDivide && _shouldSpiderfy(cluster)) {
           _spiderfy(cluster);
         }
       });

--- a/lib/src/marker_cluster_layer_options.dart
+++ b/lib/src/marker_cluster_layer_options.dart
@@ -130,6 +130,10 @@ class MarkerClusterLayerOptions {
   /// If false remove spiderfy effect on tap
   final bool spiderfyCluster;
 
+  /// If set, spiderfy will be disabled above this marker count
+  /// 0 -> No limit
+  final int disableSpiderfyAboveMarkerCount;
+
   /// Increase to increase the distance away that circle spiderfied markers appear from the center
   final int spiderfyCircleRadius;
 
@@ -210,6 +214,7 @@ class MarkerClusterLayerOptions {
     this.circleSpiralSwitchover = 9,
     this.spiderfyShapePositions,
     this.spiderfyCluster = true,
+    this.disableSpiderfyAboveMarkerCount = 0,
     this.polygonOptions = const PolygonOptions(),
     this.showPolygon = true,
     this.onMarkerTap,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_map_marker_cluster
 description: A Dart implementation of Leaflet.makercluster for Flutter apps.
   Provides beautiful animated marker clustering functionality for flutter_map.
-version: 8.1.0
+version: 8.2.2
 
 homepage: https://github.com/lpongetti/flutter_map_marker_cluster
 
@@ -12,7 +12,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_map: ^8.1.1
+  flutter_map:
+    git:
+      url: https://github.com/ben-milanko/flutter_map.git
+      ref: fix/fling-rebound
   flutter_map_marker_popup:
     git:
       url: https://github.com/enricostrijks/flutter_map_marker_popup.git


### PR DESCRIPTION
There are some instances where a large number of markers may be in the cluster and the `zoomToBoundsOnClick` is set to false.

In these cases, the asset cluster will not be useful to the user see the example below:

![image](https://github.com/user-attachments/assets/2168abb5-1f8f-46c5-9953-268dd45e6fc3)

This PR includes an additional option `disableSpiderfyAboveMarkerCount` which disables the spiderfy effect if the cluster contains more than N items.

If N is 0 or negative, the spiderfy effect will not be disabled regardless of the marker count. Default value is 0 to maintain existing behaviour for users.
